### PR TITLE
various fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1682104756
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -6,29 +6,25 @@
  */
 
 
-import com.diffplug.blowdryer.Blowdryer
-import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.gtnewhorizons.retrofuturagradle.ObfuscationAttribute
 import com.gtnewhorizons.retrofuturagradle.mcp.ReobfuscatedJar
 import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask
+import com.gtnewhorizons.retrofuturagradle.util.Distribution
 import com.matthewprenger.cursegradle.CurseArtifact
 import com.matthewprenger.cursegradle.CurseRelation
 import com.modrinth.minotaur.dependencies.ModDependency
 import com.modrinth.minotaur.dependencies.VersionDependency
-import cpw.mods.fml.relauncher.Side
-import org.gradle.api.tasks.options.Option;
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.xml.XmlTransformer
-import org.jetbrains.gradle.ext.*
+import org.jetbrains.gradle.ext.Application
+import org.jetbrains.gradle.ext.Gradle
 
+import javax.inject.Inject
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
-import javax.inject.Inject
 
 buildscript {
     repositories {
@@ -66,15 +62,18 @@ plugins {
     id 'org.jetbrains.kotlin.kapt' version '1.8.0' apply false
     id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
     id 'org.ajoberstar.grgit' version '4.1.1' // 4.1.1 is the last jvm8 supporting version, unused, available for addon.gradle
-    id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
+    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
     id 'com.palantir.git-version' version '3.0.0' apply false
-    id 'de.undercouch.download' version '5.3.0'
+    id 'de.undercouch.download' version '5.4.0'
     id 'com.github.gmazzo.buildconfig' version '3.1.0' apply false // Unused, available for addon.gradle
-    id 'com.diffplug.spotless' version '6.7.2' apply false
+    id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.2.7'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
 }
+
+print("You might want to check out './gradlew :faq' if your build fails.\n")
+
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
 if (settingsupdated)
@@ -133,7 +132,7 @@ propertyDefaultIfUnset("enableGenericInjection", false) // On by default for new
 // this is meant to be set using the user wide property file. by default we do nothing.
 propertyDefaultIfUnset("ideaOverrideBuildType", "") // Can be nothing, "gradle" or "idea"
 
-project.extensions.add(Blowdryer, "Blowdryer", Blowdryer) // Make blowdryer available in "apply from:" scripts
+project.extensions.add(com.diffplug.blowdryer.Blowdryer, "Blowdryer", com.diffplug.blowdryer.Blowdryer) // Make blowdryer available in "apply from:" scripts
 if (!disableSpotless) {
     apply plugin: 'com.diffplug.spotless'
     apply from: Blowdryer.file('spotless.gradle')
@@ -223,6 +222,8 @@ if (enableModernJavaSyntax.toBoolean()) {
 
     dependencies {
         annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
+        // workaround for https://github.com/bsideup/jabel/issues/174
+        annotationProcessor 'net.java.dev.jna:jna-platform:5.13.0'
         compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
@@ -408,7 +409,7 @@ minecraft {
 
     username = developmentEnvironmentUserName.toString()
 
-    lwjgl3Version = "3.3.2-SNAPSHOT"
+    lwjgl3Version = "3.3.2"
 
     // Enable assertions in the current mod
     extraRunJvmArguments.add("-ea:${modGroup}")
@@ -568,9 +569,10 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.6"
+def mixinProviderVersion = "0.1.7.1"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
+ext.mixinProviderSpec = mixinProviderSpec
 
 dependencies {
     if (usesMixins.toBoolean()) {
@@ -722,13 +724,13 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.3.3'
+    def lwjgl3ifyVersion = '1.3.5'
     def asmVersion = '9.4'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.4')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -802,7 +804,7 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
     public boolean setEnableHotswap(boolean enable) { enableHotswap = enable }
 
     @Inject
-    public RunHotswappableMinecraftTask(Side side, String superTask, org.gradle.api.invocation.Gradle gradle) {
+    public RunHotswappableMinecraftTask(Distribution side, String superTask, org.gradle.api.invocation.Gradle gradle) {
         super(side, gradle)
 
         this.lwjglVersion = 3
@@ -811,7 +813,7 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
         this.extraJvmArgs.addAll(project.provider(() -> enableHotswap ? project.hotswapJvmArgs : []))
 
         this.classpath(project.java17PatchDependenciesCfg)
-        if (side == Side.CLIENT) {
+        if (side == Distribution.CLIENT) {
             this.classpath(project.minecraftTasks.lwjgl3Configuration)
         }
         // Use a raw provider instead of map to not create a dependency on the task
@@ -821,9 +823,21 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
         }
         this.classpath(project.java17DependenciesCfg)
     }
+
+    public void setup(Project project) {
+        super.setup(project)
+        if (project.usesMixins.toBoolean()) {
+            this.extraJvmArgs.addAll(project.provider(() -> {
+                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(project.mixinProviderSpec))
+                mixinCfg.canBeConsumed = false
+                mixinCfg.transitive = false
+                enableHotswap ? ["-javaagent:" + mixinCfg.singleFile.absolutePath] : []
+            }))
+        }
+    }
 }
 
-def runClient17Task = tasks.register("runClient17", RunHotswappableMinecraftTask, Side.CLIENT, "runClient")
+def runClient17Task = tasks.register("runClient17", RunHotswappableMinecraftTask, Distribution.CLIENT, "runClient")
 runClient17Task.configure {
     setup(project)
     group = "Modded Minecraft"
@@ -834,7 +848,7 @@ runClient17Task.configure {
     userUUID = minecraft.userUUID
 }
 
-def runServer17Task = tasks.register("runServer17", RunHotswappableMinecraftTask, Side.SERVER, "runServer")
+def runServer17Task = tasks.register("runServer17", RunHotswappableMinecraftTask, Distribution.DEDICATED_SERVER, "runServer")
 runServer17Task.configure {
     setup(project)
     group = "Modded Minecraft"
@@ -875,11 +889,6 @@ tasks.named("jar", Jar).configure {
 }
 
 if (usesShadowedDependencies.toBoolean()) {
-    tasks.register('relocateShadowJar', ConfigureShadowRelocation) {
-        target = tasks.shadowJar
-        prefix = modGroup + ".shadow"
-        enabled = relocateShadowedDependencies.toBoolean()
-    }
     tasks.named("shadowJar", ShadowJar).configure {
         manifest {
             attributes(getManifestAttributes())
@@ -895,7 +904,8 @@ if (usesShadowedDependencies.toBoolean()) {
         ]
         archiveClassifier.set('dev')
         if (relocateShadowedDependencies.toBoolean()) {
-            dependsOn(relocateShadowJar)
+            relocationPrefix = modGroup + ".shadow"
+            enableRelocation = true
         }
     }
     configurations.runtimeElements.outgoing.artifacts.clear()
@@ -1228,7 +1238,7 @@ def addCurseForgeRelation(String type, String name) {
 
 // Updating
 
-def buildscriptGradleVersion = "8.0.2"
+def buildscriptGradleVersion = "8.1.1"
 
 tasks.named('wrapper', Wrapper).configure {
     gradleVersion = buildscriptGradleVersion
@@ -1257,6 +1267,23 @@ if (!project.getGradle().startParameter.isOffline() && !Boolean.getBoolean('DISA
         if (gradle.gradleVersion != buildscriptGradleVersion) {
             out.style(Style.SuccessHeader).println("updateBuildScript can update gradle from ${gradle.gradleVersion} to ${buildscriptGradleVersion}\n")
         }
+    }
+}
+
+// If you want to add more cases to this task, implement them as arguments if total amount to print gets too large
+tasks.register('faq') {
+    group = 'GTNH Buildscript'
+    description = 'Prints frequently asked questions about building a project'
+
+    doLast {
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
+            "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,11 +1,11 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:Mantle:0.3.6:dev")
-    api("com.github.GTNewHorizons:ForgeMultipart:1.3.2:dev")
-    implementation("com.github.GTNewHorizons:NotEnoughItems:2.3.45-GTNH:dev")
+    api("com.github.GTNewHorizons:Mantle:0.3.7:dev")
+    api("com.github.GTNewHorizons:ForgeMultipart:1.3.3:dev")
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.3.54-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.5.16:api")
-    compileOnly("com.github.GTNewHorizons:waila:1.5.24:api")
+    compileOnly("com.github.GTNewHorizons:waila:1.6.0:api")
     compileOnly("com.github.GTNewHorizons:Battlegear2:1.2.0:api") {
         transitive = false
     }

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -3,9 +3,6 @@ package tconstruct;
 import java.util.Map;
 import java.util.Random;
 
-import mantle.pulsar.config.ForgeCFG;
-import mantle.pulsar.control.PulseManager;
-
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.world.gen.structure.MapGenStructureIO;
 import net.minecraftforge.common.MinecraftForge;
@@ -14,6 +11,21 @@ import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.Mod.EventHandler;
+import cpw.mods.fml.common.Mod.Instance;
+import cpw.mods.fml.common.SidedProxy;
+import cpw.mods.fml.common.event.*;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.network.NetworkCheckHandler;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.VillagerRegistry;
+import cpw.mods.fml.relauncher.Side;
+import mantle.pulsar.config.ForgeCFG;
+import mantle.pulsar.control.PulseManager;
 import tconstruct.achievements.AchievementEvents;
 import tconstruct.achievements.TAchievements;
 import tconstruct.api.TConstructAPI;
@@ -53,19 +65,6 @@ import tconstruct.weaponry.TinkerWeaponry;
 import tconstruct.world.TinkerWorld;
 import tconstruct.world.gen.SlimeIslandGen;
 import tconstruct.world.village.*;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.Mod;
-import cpw.mods.fml.common.Mod.EventHandler;
-import cpw.mods.fml.common.Mod.Instance;
-import cpw.mods.fml.common.SidedProxy;
-import cpw.mods.fml.common.event.*;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.network.NetworkCheckHandler;
-import cpw.mods.fml.common.network.NetworkRegistry;
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.VillagerRegistry;
-import cpw.mods.fml.relauncher.Side;
 
 /**
  * TConstruct, the tool mod. Craft your tools with style, then modify until the original is gone!

--- a/src/main/java/tconstruct/achievements/AchievementEvents.java
+++ b/src/main/java/tconstruct/achievements/AchievementEvents.java
@@ -10,14 +10,14 @@ import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 
+import com.mojang.realmsclient.gui.ChatFormatting;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import tconstruct.items.tools.FryingPan;
 import tconstruct.library.event.ToolCraftedEvent;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.library.tools.Weapon;
 import tconstruct.tools.logic.ToolForgeLogic;
-
-import com.mojang.realmsclient.gui.ChatFormatting;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class AchievementEvents {
 

--- a/src/main/java/tconstruct/achievements/items/CraftAchievementItem.java
+++ b/src/main/java/tconstruct/achievements/items/CraftAchievementItem.java
@@ -1,12 +1,11 @@
 package tconstruct.achievements.items;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import mantle.items.abstracts.CraftingItem;
 import tconstruct.achievements.TAchievements;
 
 public class CraftAchievementItem extends CraftingItem {

--- a/src/main/java/tconstruct/armor/ArmorAbilities.java
+++ b/src/main/java/tconstruct/armor/ArmorAbilities.java
@@ -8,14 +8,14 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
 import tconstruct.TConstruct;
 import tconstruct.armor.items.TravelGear;
 import tconstruct.armor.player.TPlayerStats;
 import tconstruct.library.modifier.IModifyable;
 import tconstruct.util.network.HealthUpdatePacket;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.gameevent.PlayerEvent;
-import cpw.mods.fml.common.gameevent.TickEvent;
 
 public class ArmorAbilities {
 

--- a/src/main/java/tconstruct/armor/ArmorProxyClient.java
+++ b/src/main/java/tconstruct/armor/ArmorProxyClient.java
@@ -2,8 +2,6 @@ package tconstruct.armor;
 
 import java.util.Random;
 
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.model.ModelBiped;
@@ -28,6 +26,10 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 import net.minecraftforge.common.MinecraftForge;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import mantle.lib.client.MantleClientRegistry;
 import tconstruct.armor.gui.ArmorExtendedGui;
 import tconstruct.armor.gui.KnapsackGui;
 import tconstruct.armor.items.TravelGear;
@@ -48,9 +50,6 @@ import tconstruct.library.accessory.IAccessoryModel;
 import tconstruct.library.client.TConstructClientRegistry;
 import tconstruct.library.crafting.ModifyBuilder;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class ArmorProxyClient extends ArmorProxyCommon {
 

--- a/src/main/java/tconstruct/armor/ArmorProxyCommon.java
+++ b/src/main/java/tconstruct/armor/ArmorProxyCommon.java
@@ -4,12 +4,12 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.network.IGuiHandler;
 import tconstruct.TConstruct;
 import tconstruct.armor.inventory.ArmorExtendedContainer;
 import tconstruct.armor.inventory.KnapsackContainer;
 import tconstruct.armor.player.TPlayerStats;
 import tconstruct.common.TProxyCommon;
-import cpw.mods.fml.common.network.IGuiHandler;
 
 public class ArmorProxyCommon implements IGuiHandler {
 

--- a/src/main/java/tconstruct/armor/ArmorTickHandler.java
+++ b/src/main/java/tconstruct/armor/ArmorTickHandler.java
@@ -2,11 +2,11 @@ package tconstruct.armor;
 
 import net.minecraft.client.Minecraft;
 
-import tconstruct.client.ArmorControls;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.ClientTickEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.client.ArmorControls;
 
 public class ArmorTickHandler {
 

--- a/src/main/java/tconstruct/armor/TinkerArmor.java
+++ b/src/main/java/tconstruct/armor/TinkerArmor.java
@@ -2,9 +2,6 @@ package tconstruct.armor;
 
 import java.util.EnumSet;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -15,6 +12,16 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.EnumHelper;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.SidedProxy;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.armor.blocks.DryingRack;
 import tconstruct.armor.items.*;
@@ -31,14 +38,6 @@ import tconstruct.modifiers.tools.ModAttack;
 import tconstruct.tools.TinkerTools;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.SidedProxy;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(id = "Tinkers' Armory", description = "Modifyable armors, such as the traveller's gear.")

--- a/src/main/java/tconstruct/armor/TinkerArmorEvents.java
+++ b/src/main/java/tconstruct/armor/TinkerArmorEvents.java
@@ -16,13 +16,13 @@ import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import tconstruct.TConstruct;
 import tconstruct.armor.items.TravelWings;
 import tconstruct.armor.player.TPlayerStats;
 import tconstruct.library.modifier.IModifyable;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.util.network.ArmourGuiSyncPacket;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class TinkerArmorEvents {
 

--- a/src/main/java/tconstruct/armor/blocks/DryingRack.java
+++ b/src/main/java/tconstruct/armor/blocks/DryingRack.java
@@ -2,8 +2,6 @@ package tconstruct.armor.blocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.InventoryBlock;
-
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -17,13 +15,14 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryBlock;
 import tconstruct.TConstruct;
 import tconstruct.armor.modelblock.DryingRackRender;
 import tconstruct.blocks.logic.DryingRackLogic;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.AbilityHelper;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class DryingRack extends InventoryBlock {
 

--- a/src/main/java/tconstruct/armor/inventory/SlotOpaqueBlocksOnly.java
+++ b/src/main/java/tconstruct/armor/inventory/SlotOpaqueBlocksOnly.java
@@ -1,10 +1,10 @@
 package tconstruct.armor.inventory;
 
-import mantle.blocks.BlockUtils;
-
 import net.minecraft.block.Block;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+
+import mantle.blocks.BlockUtils;
 
 /**
  *

--- a/src/main/java/tconstruct/armor/items/ArmorPattern.java
+++ b/src/main/java/tconstruct/armor/items/ArmorPattern.java
@@ -2,18 +2,17 @@ package tconstruct.armor.items;
 
 import java.util.List;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 
-import tconstruct.library.ItemBlocklike;
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.items.abstracts.CraftingItem;
+import tconstruct.library.ItemBlocklike;
+import tconstruct.library.TConstructRegistry;
 
 public class ArmorPattern extends CraftingItem implements ItemBlocklike {
 

--- a/src/main/java/tconstruct/armor/items/HeartCanister.java
+++ b/src/main/java/tconstruct/armor/items/HeartCanister.java
@@ -2,20 +2,19 @@ package tconstruct.armor.items;
 
 import java.util.List;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumAction;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.items.abstracts.CraftingItem;
 import tconstruct.armor.player.ArmorExtended;
 import tconstruct.armor.player.TPlayerStats;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.accessory.IHealthAccessory;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class HeartCanister extends CraftingItem implements IHealthAccessory {
 

--- a/src/main/java/tconstruct/armor/items/Jerky.java
+++ b/src/main/java/tconstruct/armor/items/Jerky.java
@@ -12,9 +12,9 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import tconstruct.world.items.SpecialFood;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.world.items.SpecialFood;
 
 public class Jerky extends SpecialFood {
 

--- a/src/main/java/tconstruct/armor/items/Knapsack.java
+++ b/src/main/java/tconstruct/armor/items/Knapsack.java
@@ -2,16 +2,15 @@ package tconstruct.armor.items;
 
 import java.util.List;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
-import tconstruct.library.TConstructRegistry;
-import tconstruct.library.accessory.IAccessory;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.items.abstracts.CraftingItem;
+import tconstruct.library.TConstructRegistry;
+import tconstruct.library.accessory.IAccessory;
 
 public class Knapsack extends CraftingItem implements IAccessory {
 

--- a/src/main/java/tconstruct/armor/items/TravelBelt.java
+++ b/src/main/java/tconstruct/armor/items/TravelBelt.java
@@ -12,12 +12,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.armor.ArmorProxyClient;
 import tconstruct.client.ArmorControls;
 import tconstruct.library.accessory.AccessoryCore;
 import tconstruct.library.accessory.IAccessoryModel;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class TravelBelt extends AccessoryCore implements IAccessoryModel {
 

--- a/src/main/java/tconstruct/armor/items/TravelGear.java
+++ b/src/main/java/tconstruct/armor/items/TravelGear.java
@@ -13,15 +13,15 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.armor.ArmorProxyClient;
 import tconstruct.armor.TinkerArmor;
 import tconstruct.library.armor.ArmorCore;
 import tconstruct.library.armor.ArmorPart;
 import thaumcraft.api.IGoggles;
 import thaumcraft.api.nodes.IRevealer;
-import cpw.mods.fml.common.Optional;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 @Optional.InterfaceList({ @Optional.Interface(modid = "Thaumcraft", iface = "thaumcraft.api.nodes.IRevealer"),
         @Optional.Interface(modid = "Thaumcraft", iface = "thaumcraft.api.IGoggles") })

--- a/src/main/java/tconstruct/armor/items/TravelGlove.java
+++ b/src/main/java/tconstruct/armor/items/TravelGlove.java
@@ -8,11 +8,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.armor.ArmorProxyClient;
 import tconstruct.library.accessory.AccessoryCore;
 import tconstruct.library.accessory.IAccessoryModel;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class TravelGlove extends AccessoryCore implements IAccessoryModel {
 

--- a/src/main/java/tconstruct/armor/items/TravelWings.java
+++ b/src/main/java/tconstruct/armor/items/TravelWings.java
@@ -8,10 +8,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
-import tconstruct.library.armor.ArmorPart;
-import tconstruct.tools.TinkerTools;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.library.armor.ArmorPart;
+import tconstruct.tools.TinkerTools;
 
 public class TravelWings extends TravelGear {
 

--- a/src/main/java/tconstruct/armor/modelblock/DryingRackRender.java
+++ b/src/main/java/tconstruct/armor/modelblock/DryingRackRender.java
@@ -7,9 +7,9 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.util.ItemHelper;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.util.ItemHelper;
 
 public class DryingRackRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/armor/modelblock/DryingRackSpecialRender.java
+++ b/src/main/java/tconstruct/armor/modelblock/DryingRackSpecialRender.java
@@ -9,10 +9,10 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.blocks.logic.DryingRackLogic;
-import tconstruct.tools.entity.FancyEntityItem;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.blocks.logic.DryingRackLogic;
+import tconstruct.tools.entity.FancyEntityItem;
 
 /* Special renderer, only used for drawing tools */
 

--- a/src/main/java/tconstruct/armor/player/ArmorExtended.java
+++ b/src/main/java/tconstruct/armor/player/ArmorExtended.java
@@ -14,12 +14,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
-import tconstruct.library.accessory.IHealthAccessory;
-import tconstruct.util.config.PHConstruct;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.relauncher.Side;
 import io.netty.buffer.ByteBuf;
+import tconstruct.library.accessory.IHealthAccessory;
+import tconstruct.util.config.PHConstruct;
 
 public class ArmorExtended implements IInventory {
 

--- a/src/main/java/tconstruct/armor/player/TPlayerHandler.java
+++ b/src/main/java/tconstruct/armor/player/TPlayerHandler.java
@@ -9,8 +9,6 @@ import java.util.HashSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import mantle.player.PlayerUtils;
-
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.Entity.EnumEntitySize;
@@ -25,16 +23,17 @@ import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.player.PlayerDropsEvent;
 
-import tconstruct.TConstruct;
-import tconstruct.library.tools.AbilityHelper;
-import tconstruct.tools.TinkerTools;
-import tconstruct.util.config.PHConstruct;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerRespawnEvent;
 import cpw.mods.fml.relauncher.Side;
+import mantle.player.PlayerUtils;
+import tconstruct.TConstruct;
+import tconstruct.library.tools.AbilityHelper;
+import tconstruct.tools.TinkerTools;
+import tconstruct.util.config.PHConstruct;
 
 // TODO: Redesign this class
 public class TPlayerHandler {

--- a/src/main/java/tconstruct/blocks/SlabBase.java
+++ b/src/main/java/tconstruct/blocks/SlabBase.java
@@ -2,8 +2,6 @@ package tconstruct.blocks;
 
 import java.util.List;
 
-import mantle.blocks.MantleBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -16,9 +14,10 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
+import tconstruct.library.TConstructRegistry;
 
 public class SlabBase extends MantleBlock {
 

--- a/src/main/java/tconstruct/blocks/TConstructBlock.java
+++ b/src/main/java/tconstruct/blocks/TConstructBlock.java
@@ -2,8 +2,6 @@ package tconstruct.blocks;
 
 import java.util.List;
 
-import mantle.blocks.MantleBlock;
-
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
@@ -11,9 +9,10 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
+import tconstruct.library.TConstructRegistry;
 
 public class TConstructBlock extends MantleBlock {
 

--- a/src/main/java/tconstruct/blocks/logic/DryingRackLogic.java
+++ b/src/main/java/tconstruct/blocks/logic/DryingRackLogic.java
@@ -1,7 +1,5 @@
 package tconstruct.blocks.logic;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
@@ -12,9 +10,10 @@ import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 
-import tconstruct.library.crafting.DryingRackRecipes;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryLogic;
+import tconstruct.library.crafting.DryingRackRecipes;
 
 public class DryingRackLogic extends InventoryLogic {
 

--- a/src/main/java/tconstruct/blocks/slime/SlimeFluid.java
+++ b/src/main/java/tconstruct/blocks/slime/SlimeFluid.java
@@ -12,12 +12,12 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.BlockFluidClassic;
 import net.minecraftforge.fluids.Fluid;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.world.TinkerWorld;
 import tconstruct.world.entity.BlueSlime;
 import tconstruct.world.entity.KingBlueSlime;
 import tconstruct.world.entity.SlimeBase;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class SlimeFluid extends BlockFluidClassic {
 

--- a/src/main/java/tconstruct/blocks/slime/SlimeGel.java
+++ b/src/main/java/tconstruct/blocks/slime/SlimeGel.java
@@ -13,10 +13,10 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 
-import tconstruct.blocks.TConstructBlock;
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.blocks.TConstructBlock;
+import tconstruct.library.TConstructRegistry;
 
 public class SlimeGel extends TConstructBlock {
 

--- a/src/main/java/tconstruct/blocks/slime/SlimeGrass.java
+++ b/src/main/java/tconstruct/blocks/slime/SlimeGrass.java
@@ -3,8 +3,6 @@ package tconstruct.blocks.slime;
 import java.util.List;
 import java.util.Random;
 
-import mantle.blocks.MantleBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -20,10 +18,11 @@ import net.minecraftforge.common.EnumPlantType;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import tconstruct.library.TConstructRegistry;
-import tconstruct.tools.TinkerTools;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
+import tconstruct.library.TConstructRegistry;
+import tconstruct.tools.TinkerTools;
 
 public class SlimeGrass extends MantleBlock {
 

--- a/src/main/java/tconstruct/blocks/slime/SlimeLeaves.java
+++ b/src/main/java/tconstruct/blocks/slime/SlimeLeaves.java
@@ -13,10 +13,10 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.library.TConstructRegistry;
-import tconstruct.world.TinkerWorld;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.library.TConstructRegistry;
+import tconstruct.world.TinkerWorld;
 
 public class SlimeLeaves extends BlockLeaves {
 

--- a/src/main/java/tconstruct/blocks/slime/SlimeSapling.java
+++ b/src/main/java/tconstruct/blocks/slime/SlimeSapling.java
@@ -15,12 +15,12 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenerator;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.tools.TinkerTools;
 import tconstruct.world.TinkerWorld;
 import tconstruct.world.gen.SlimeTreeGen;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class SlimeSapling extends BlockSapling {
 

--- a/src/main/java/tconstruct/blocks/slime/SlimeTallGrass.java
+++ b/src/main/java/tconstruct/blocks/slime/SlimeTallGrass.java
@@ -17,9 +17,9 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.IShearable;
 
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.library.TConstructRegistry;
 
 public class SlimeTallGrass extends BlockBush implements IShearable {
 

--- a/src/main/java/tconstruct/blocks/traps/BarricadeBlock.java
+++ b/src/main/java/tconstruct/blocks/traps/BarricadeBlock.java
@@ -1,7 +1,5 @@
 package tconstruct.blocks.traps;
 
-import mantle.blocks.MantleBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -15,10 +13,11 @@ import net.minecraft.world.Explosion;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.library.TConstructRegistry;
-import tconstruct.world.model.BarricadeRender;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
+import tconstruct.library.TConstructRegistry;
+import tconstruct.world.model.BarricadeRender;
 
 public class BarricadeBlock extends MantleBlock {
 

--- a/src/main/java/tconstruct/blocks/traps/Landmine.java
+++ b/src/main/java/tconstruct/blocks/traps/Landmine.java
@@ -4,9 +4,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
-import mantle.blocks.MantleBlock;
-import mantle.world.WorldHelper;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFence;
 import net.minecraft.block.material.Material;
@@ -20,9 +17,11 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
+import mantle.world.WorldHelper;
+import tconstruct.library.TConstructRegistry;
 
 public class Landmine extends MantleBlock {
 

--- a/src/main/java/tconstruct/blocks/traps/Punji.java
+++ b/src/main/java/tconstruct/blocks/traps/Punji.java
@@ -2,8 +2,6 @@ package tconstruct.blocks.traps;
 
 import java.util.Random;
 
-import mantle.blocks.MantleBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -18,11 +16,12 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.world.TinkerWorld;
 import tconstruct.world.model.PunjiRender;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class Punji extends MantleBlock {
 

--- a/src/main/java/tconstruct/client/ArmorControls.java
+++ b/src/main/java/tconstruct/client/ArmorControls.java
@@ -1,9 +1,5 @@
 package tconstruct.client;
 
-import mantle.common.network.AbstractPacket;
-import modwarriors.notenoughkeys.api.Api;
-import modwarriors.notenoughkeys.api.KeyBindingPressedEvent;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.item.ItemStack;
@@ -12,6 +8,14 @@ import net.minecraft.potion.Potion;
 
 import org.lwjgl.input.Keyboard;
 
+import cpw.mods.fml.client.registry.ClientRegistry;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent;
+import mantle.common.network.AbstractPacket;
+import modwarriors.notenoughkeys.api.Api;
+import modwarriors.notenoughkeys.api.KeyBindingPressedEvent;
 import tconstruct.TConstruct;
 import tconstruct.armor.ArmorProxyClient;
 import tconstruct.armor.ArmorProxyCommon;
@@ -21,11 +25,6 @@ import tconstruct.util.network.AccessoryInventoryPacket;
 import tconstruct.util.network.BeltPacket;
 import tconstruct.util.network.DoubleJumpPacket;
 import tconstruct.util.network.GogglePacket;
-import cpw.mods.fml.client.registry.ClientRegistry;
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.Optional;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent;
 
 public class ArmorControls {
 

--- a/src/main/java/tconstruct/client/TProxyClient.java
+++ b/src/main/java/tconstruct/client/TProxyClient.java
@@ -6,9 +6,6 @@ import java.text.DecimalFormat;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import mantle.client.SmallFontRenderer;
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.init.Blocks;
@@ -19,6 +16,8 @@ import net.minecraft.util.ResourceLocation;
 
 import org.w3c.dom.Document;
 
+import mantle.client.SmallFontRenderer;
+import mantle.lib.client.MantleClientRegistry;
 import tconstruct.TConstruct;
 import tconstruct.armor.ArmorProxyClient;
 import tconstruct.armor.player.TPlayerStats;

--- a/src/main/java/tconstruct/client/entity/item/ExplosiveRender.java
+++ b/src/main/java/tconstruct/client/entity/item/ExplosiveRender.java
@@ -9,10 +9,10 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.mechworks.entity.item.ExplosivePrimed;
-import tconstruct.world.TinkerWorld;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.mechworks.entity.item.ExplosivePrimed;
+import tconstruct.world.TinkerWorld;
 
 @SideOnly(Side.CLIENT)
 public class ExplosiveRender extends Render {

--- a/src/main/java/tconstruct/client/entity/projectile/ArrowRender.java
+++ b/src/main/java/tconstruct/client/entity/projectile/ArrowRender.java
@@ -2,8 +2,6 @@ package tconstruct.client.entity.projectile;
 
 import java.util.Random;
 
-import mantle.blocks.BlockUtils;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemRenderer;
@@ -21,9 +19,10 @@ import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import tconstruct.tools.entity.ArrowEntity;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.BlockUtils;
+import tconstruct.tools.entity.ArrowEntity;
 
 @SideOnly(Side.CLIENT)
 @Deprecated

--- a/src/main/java/tconstruct/client/entity/projectile/ArrowRenderCustom.java
+++ b/src/main/java/tconstruct/client/entity/projectile/ArrowRenderCustom.java
@@ -15,9 +15,9 @@ import net.minecraftforge.client.ForgeHooksClient;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import tconstruct.tools.entity.ArrowEntity;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.tools.entity.ArrowEntity;
 
 @SideOnly(Side.CLIENT)
 @Deprecated

--- a/src/main/java/tconstruct/client/entity/projectile/DaggerRender.java
+++ b/src/main/java/tconstruct/client/entity/projectile/DaggerRender.java
@@ -2,8 +2,6 @@ package tconstruct.client.entity.projectile;
 
 import java.util.Random;
 
-import mantle.blocks.BlockUtils;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -24,9 +22,10 @@ import net.minecraftforge.client.ForgeHooksClient;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import tconstruct.tools.entity.DaggerEntity;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.BlockUtils;
+import tconstruct.tools.entity.DaggerEntity;
 
 @SideOnly(Side.CLIENT)
 @Deprecated

--- a/src/main/java/tconstruct/client/entity/projectile/DaggerRenderCustom.java
+++ b/src/main/java/tconstruct/client/entity/projectile/DaggerRenderCustom.java
@@ -16,10 +16,10 @@ import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import tconstruct.client.ToolCoreRenderer;
-import tconstruct.tools.entity.DaggerEntity;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.client.ToolCoreRenderer;
+import tconstruct.tools.entity.DaggerEntity;
 
 @SideOnly(Side.CLIENT)
 @Deprecated

--- a/src/main/java/tconstruct/client/entity/projectile/LaunchedItemRender.java
+++ b/src/main/java/tconstruct/client/entity/projectile/LaunchedItemRender.java
@@ -13,9 +13,9 @@ import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import tconstruct.tools.entity.LaunchedPotion;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.tools.entity.LaunchedPotion;
 
 @SideOnly(Side.CLIENT)
 public class LaunchedItemRender extends Render {

--- a/src/main/java/tconstruct/client/pages/BlockCastPage.java
+++ b/src/main/java/tconstruct/client/pages/BlockCastPage.java
@@ -1,8 +1,5 @@
 package tconstruct.client.pages;
 
-import mantle.client.pages.BookPage;
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -12,6 +9,9 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import mantle.client.pages.BookPage;
+import mantle.lib.client.MantleClientRegistry;
 
 public class BlockCastPage extends BookPage {
 

--- a/src/main/java/tconstruct/client/pages/MaterialPage.java
+++ b/src/main/java/tconstruct/client/pages/MaterialPage.java
@@ -1,8 +1,5 @@
 package tconstruct.client.pages;
 
-import mantle.client.pages.BookPage;
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
@@ -12,6 +9,8 @@ import org.lwjgl.opengl.GL12;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
+import mantle.client.pages.BookPage;
+import mantle.lib.client.MantleClientRegistry;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.PatternBuilder;
 import tconstruct.library.tools.ToolMaterial;

--- a/src/main/java/tconstruct/client/pages/ModifierPage.java
+++ b/src/main/java/tconstruct/client/pages/ModifierPage.java
@@ -3,9 +3,6 @@ package tconstruct.client.pages;
 import java.util.LinkedList;
 import java.util.List;
 
-import mantle.client.pages.BookPage;
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -15,6 +12,9 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import mantle.client.pages.BookPage;
+import mantle.lib.client.MantleClientRegistry;
 
 public class ModifierPage extends BookPage {
 

--- a/src/main/java/tconstruct/client/pages/ToolPage.java
+++ b/src/main/java/tconstruct/client/pages/ToolPage.java
@@ -1,8 +1,5 @@
 package tconstruct.client.pages;
 
-import mantle.client.pages.BookPage;
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
@@ -11,6 +8,9 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import mantle.client.pages.BookPage;
+import mantle.lib.client.MantleClientRegistry;
 
 public class ToolPage extends BookPage {
 

--- a/src/main/java/tconstruct/gadgets/TinkerGadgets.java
+++ b/src/main/java/tconstruct/gadgets/TinkerGadgets.java
@@ -2,9 +2,6 @@ package tconstruct.gadgets;
 
 import java.util.Locale;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -14,15 +11,17 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.gadgets.item.ItemSlimeBoots;
 import tconstruct.gadgets.item.ItemSlimeSling;
 import tconstruct.library.SlimeBounceHandler;
 import tconstruct.library.TConstructRegistry;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
 
 @Pulse(id = "Tinkers' Gadgets", description = "All the fun toys.", forced = true)
 public class TinkerGadgets {

--- a/src/main/java/tconstruct/gadgets/item/ItemSlimeBoots.java
+++ b/src/main/java/tconstruct/gadgets/item/ItemSlimeBoots.java
@@ -24,13 +24,13 @@ import net.minecraftforge.common.ISpecialArmor;
 import net.minecraftforge.common.util.EnumHelper;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.SlimeBounceHandler;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.armor.ArmorPart;
 import tconstruct.tools.entity.FancyEntityItem;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemSlimeBoots extends ItemArmor implements ISpecialArmor {
 

--- a/src/main/java/tconstruct/gadgets/item/ItemSlimeSling.java
+++ b/src/main/java/tconstruct/gadgets/item/ItemSlimeSling.java
@@ -15,13 +15,13 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.TConstruct;
 import tconstruct.gadgets.TinkerGadgets;
 import tconstruct.library.SlimeBounceHandler;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.util.network.MovementUpdatePacket;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemSlimeSling extends Item {
 

--- a/src/main/java/tconstruct/items/tools/Arrow.java
+++ b/src/main/java/tconstruct/items/tools/Arrow.java
@@ -10,14 +10,14 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.tools.CustomMaterial;
 import tconstruct.library.tools.FletchingMaterial;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.weaponry.TinkerWeaponry;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 @Deprecated
 public class Arrow extends ToolCore {

--- a/src/main/java/tconstruct/items/tools/BattleSign.java
+++ b/src/main/java/tconstruct/items/tools/BattleSign.java
@@ -5,13 +5,13 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
 import tconstruct.TConstruct;
 import tconstruct.library.tools.Weapon;
 import tconstruct.tools.TinkerTools;
 import tconstruct.tools.ToolProxyClient;
 import tconstruct.tools.logic.EquipLogic;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.relauncher.Side;
 
 public class BattleSign extends Weapon {
 

--- a/src/main/java/tconstruct/items/tools/Battleaxe.java
+++ b/src/main/java/tconstruct/items/tools/Battleaxe.java
@@ -1,8 +1,5 @@
 package tconstruct.items.tools;
 
-import mods.battlegear2.api.PlayerEventChild;
-import mods.battlegear2.api.weapons.IBattlegearWeapon;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -18,12 +15,14 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
-import tconstruct.library.tools.AOEHarvestTool;
-import tconstruct.library.tools.AbilityHelper;
-import tconstruct.tools.TinkerTools;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mods.battlegear2.api.PlayerEventChild;
+import mods.battlegear2.api.weapons.IBattlegearWeapon;
+import tconstruct.library.tools.AOEHarvestTool;
+import tconstruct.library.tools.AbilityHelper;
+import tconstruct.tools.TinkerTools;
 
 @Optional.InterfaceList({
         @Optional.Interface(modid = "battlegear2", iface = "mods.battlegear2.api.weapons.IBattlegearWeapon"),

--- a/src/main/java/tconstruct/items/tools/Chisel.java
+++ b/src/main/java/tconstruct/items/tools/Chisel.java
@@ -12,14 +12,14 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.MovingObjectPosition.MovingObjectType;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.TConstruct;
 import tconstruct.library.crafting.Detailing.DetailInput;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.modifiers.tools.ModMoss;
 import tconstruct.tools.TinkerTools;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class Chisel extends ToolCore {
 

--- a/src/main/java/tconstruct/items/tools/Longsword.java
+++ b/src/main/java/tconstruct/items/tools/Longsword.java
@@ -9,10 +9,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
-import tconstruct.library.tools.Weapon;
-import tconstruct.tools.TinkerTools;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.library.tools.Weapon;
+import tconstruct.tools.TinkerTools;
 
 public class Longsword extends Weapon {
 

--- a/src/main/java/tconstruct/items/tools/LumberAxe.java
+++ b/src/main/java/tconstruct/items/tools/LumberAxe.java
@@ -4,8 +4,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.Stack;
 
-import mantle.player.PlayerUtils;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
@@ -16,12 +14,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.World;
 
-import tconstruct.library.ActiveToolMod;
-import tconstruct.library.TConstructRegistry;
-import tconstruct.library.tools.AOEHarvestTool;
-import tconstruct.library.tools.AbilityHelper;
-import tconstruct.tools.TinkerTools;
-
 import com.google.common.collect.Lists;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -29,6 +21,12 @@ import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import gnu.trove.set.hash.THashSet;
+import mantle.player.PlayerUtils;
+import tconstruct.library.ActiveToolMod;
+import tconstruct.library.TConstructRegistry;
+import tconstruct.library.tools.AOEHarvestTool;
+import tconstruct.library.tools.AbilityHelper;
+import tconstruct.tools.TinkerTools;
 
 public class LumberAxe extends AOEHarvestTool {
 

--- a/src/main/java/tconstruct/items/tools/PotionLauncher.java
+++ b/src/main/java/tconstruct/items/tools/PotionLauncher.java
@@ -16,9 +16,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import tconstruct.tools.entity.LaunchedPotion;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.tools.entity.LaunchedPotion;
 
 public class PotionLauncher extends Item {
 

--- a/src/main/java/tconstruct/items/tools/Scythe.java
+++ b/src/main/java/tconstruct/items/tools/Scythe.java
@@ -23,12 +23,12 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IShearable;
 
+import cpw.mods.fml.client.FMLClientHandler;
 import tconstruct.library.ActiveToolMod;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.library.tools.Weapon;
 import tconstruct.tools.TinkerTools;
-import cpw.mods.fml.client.FMLClientHandler;
 
 public class Scythe extends Weapon {
 

--- a/src/main/java/tconstruct/items/tools/Shortbow.java
+++ b/src/main/java/tconstruct/items/tools/Shortbow.java
@@ -11,13 +11,13 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.BowstringMaterial;
 import tconstruct.library.tools.CustomMaterial;
 import tconstruct.tools.TinkerTools;
 import tconstruct.weaponry.TinkerWeaponry;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 @Deprecated
 public class Shortbow extends BowBase {

--- a/src/main/java/tconstruct/library/SlimeBounceHandler.java
+++ b/src/main/java/tconstruct/library/SlimeBounceHandler.java
@@ -9,10 +9,10 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 
-import tconstruct.gadgets.TinkerGadgets;
-import tconstruct.gadgets.item.ItemSlimeBoots;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import tconstruct.gadgets.TinkerGadgets;
+import tconstruct.gadgets.item.ItemSlimeBoots;
 
 /** Logic for entities bouncing */
 public class SlimeBounceHandler {

--- a/src/main/java/tconstruct/library/accessory/AccessoryCore.java
+++ b/src/main/java/tconstruct/library/accessory/AccessoryCore.java
@@ -10,11 +10,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.modifier.IModifyable;
 import tconstruct.library.tools.ToolCore;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public abstract class AccessoryCore extends Item implements IAccessory, IModifyable {
 

--- a/src/main/java/tconstruct/library/armor/ArmorCore.java
+++ b/src/main/java/tconstruct/library/armor/ArmorCore.java
@@ -22,13 +22,13 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.modifier.ActiveArmorMod;
 import tconstruct.library.modifier.IModifyable;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.tools.entity.FancyEntityItem;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public abstract class ArmorCore extends ItemArmor implements ISpecialArmor, IModifyable {
 

--- a/src/main/java/tconstruct/library/client/TConstructClientRegistry.java
+++ b/src/main/java/tconstruct/library/client/TConstructClientRegistry.java
@@ -4,11 +4,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import mantle.lib.client.MantleClientRegistry;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ModifyBuilder;
 import tconstruct.library.tools.ToolCore;

--- a/src/main/java/tconstruct/library/component/TankLayerScan.java
+++ b/src/main/java/tconstruct/library/component/TankLayerScan.java
@@ -5,18 +5,17 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 
-import mantle.blocks.iface.IFacingLogic;
-import mantle.blocks.iface.IMasterLogic;
-import mantle.blocks.iface.IServantLogic;
-import mantle.world.CoordTuple;
-import mantle.world.CoordTupleSort;
-
 import net.minecraft.block.Block;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagIntArray;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 
+import mantle.blocks.iface.IFacingLogic;
+import mantle.blocks.iface.IMasterLogic;
+import mantle.blocks.iface.IServantLogic;
+import mantle.world.CoordTuple;
+import mantle.world.CoordTupleSort;
 import tconstruct.TConstruct;
 
 public class TankLayerScan extends LogicComponent {

--- a/src/main/java/tconstruct/library/crafting/Detailing.java
+++ b/src/main/java/tconstruct/library/crafting/Detailing.java
@@ -8,8 +8,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import tconstruct.library.tools.ToolCore;
 import cpw.mods.fml.common.registry.GameRegistry;
+import tconstruct.library.tools.ToolCore;
 
 public class Detailing {
 

--- a/src/main/java/tconstruct/library/crafting/LiquidCasting.java
+++ b/src/main/java/tconstruct/library/crafting/LiquidCasting.java
@@ -7,6 +7,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import tconstruct.library.client.FluidRenderProperties;
 import tconstruct.smeltery.TinkerSmeltery;
+import tconstruct.weaponry.TinkerWeaponry;
 
 /* Melting becomes hardened */
 public class LiquidCasting {
@@ -38,6 +39,11 @@ public class LiquidCasting {
         // Ceramic Cast Mirror
         if (cast != null && cast.getItem() == TinkerSmeltery.metalPattern) {
             ItemStack ceramic_cast = new ItemStack(TinkerSmeltery.ceramicPattern, 1, cast.getItemDamage());
+            CastingRecipe ccr = new CastingRecipe(output, metal, ceramic_cast, true, delay, props);
+            if (!contains(ccr)) casts.add(ccr);
+        }
+        else if (cast != null && cast.getItem() == TinkerWeaponry.metalPattern) {
+            ItemStack ceramic_cast = new ItemStack(TinkerWeaponry.ceramicPattern, 1, cast.getItemDamage());
             CastingRecipe ccr = new CastingRecipe(output, metal, ceramic_cast, true, delay, props);
             if (!contains(ccr)) casts.add(ccr);
         }

--- a/src/main/java/tconstruct/library/crafting/LiquidCasting.java
+++ b/src/main/java/tconstruct/library/crafting/LiquidCasting.java
@@ -41,8 +41,7 @@ public class LiquidCasting {
             ItemStack ceramic_cast = new ItemStack(TinkerSmeltery.ceramicPattern, 1, cast.getItemDamage());
             CastingRecipe ccr = new CastingRecipe(output, metal, ceramic_cast, true, delay, props);
             if (!contains(ccr)) casts.add(ccr);
-        }
-        else if (cast != null && cast.getItem() == TinkerWeaponry.metalPattern) {
+        } else if (cast != null && cast.getItem() == TinkerWeaponry.metalPattern) {
             ItemStack ceramic_cast = new ItemStack(TinkerWeaponry.ceramicPattern, 1, cast.getItemDamage());
             CastingRecipe ccr = new CastingRecipe(output, metal, ceramic_cast, true, delay, props);
             if (!contains(ccr)) casts.add(ccr);

--- a/src/main/java/tconstruct/library/crafting/PatternBuilder.java
+++ b/src/main/java/tconstruct/library/crafting/PatternBuilder.java
@@ -10,11 +10,11 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 
+import cpw.mods.fml.common.eventhandler.Event.Result;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.event.PartBuilderEvent;
 import tconstruct.library.tools.CustomMaterial;
 import tconstruct.library.util.IPattern;
-import cpw.mods.fml.common.eventhandler.Event.Result;
 
 public class PatternBuilder {
 

--- a/src/main/java/tconstruct/library/crafting/Smeltery.java
+++ b/src/main/java/tconstruct/library/crafting/Smeltery.java
@@ -5,14 +5,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import mantle.utils.ItemMetaWrapper;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
+
+import mantle.utils.ItemMetaWrapper;
 
 /** Melting and hacking, churn and burn */
 public class Smeltery {

--- a/src/main/java/tconstruct/library/crafting/ToolBuilder.java
+++ b/src/main/java/tconstruct/library/crafting/ToolBuilder.java
@@ -11,6 +11,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.MinecraftForge;
 
+import cpw.mods.fml.common.eventhandler.Event.Result;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.event.ToolBuildEvent;
 import tconstruct.library.event.ToolCraftEvent;
@@ -18,7 +19,6 @@ import tconstruct.library.modifier.ItemModifier;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.library.tools.ToolMaterial;
 import tconstruct.library.util.IToolPart;
-import cpw.mods.fml.common.eventhandler.Event.Result;
 
 public class ToolBuilder {
 

--- a/src/main/java/tconstruct/library/entity/ProjectileBase.java
+++ b/src/main/java/tconstruct/library/entity/ProjectileBase.java
@@ -17,6 +17,9 @@ import net.minecraft.network.play.server.S2BPacketChangeGameState;
 import net.minecraft.util.*;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
+import io.netty.buffer.ByteBuf;
 import tconstruct.library.ActiveToolMod;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.AbilityHelper;
@@ -25,9 +28,6 @@ import tconstruct.library.weaponry.AmmoItem;
 import tconstruct.modifiers.tools.ModMoss;
 import tconstruct.util.Reference;
 import tconstruct.weaponry.entity.ArrowEntity;
-import cpw.mods.fml.common.network.ByteBufUtils;
-import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
-import io.netty.buffer.ByteBuf;
 
 // have to base this on EntityArrow, otherwise minecraft does derp things because everything is handled based on class.
 public abstract class ProjectileBase extends EntityArrow implements IEntityAdditionalSpawnData {

--- a/src/main/java/tconstruct/library/event/ModifyEvent.java
+++ b/src/main/java/tconstruct/library/event/ModifyEvent.java
@@ -2,10 +2,10 @@ package tconstruct.library.event;
 
 import net.minecraft.item.ItemStack;
 
-import tconstruct.library.modifier.IModifyable;
-import tconstruct.library.modifier.ItemModifier;
 import cpw.mods.fml.common.eventhandler.Cancelable;
 import cpw.mods.fml.common.eventhandler.Event;
+import tconstruct.library.modifier.IModifyable;
+import tconstruct.library.modifier.ItemModifier;
 
 @Cancelable
 public class ModifyEvent extends Event {

--- a/src/main/java/tconstruct/library/event/SmelteryCastEvent.java
+++ b/src/main/java/tconstruct/library/event/SmelteryCastEvent.java
@@ -2,8 +2,8 @@ package tconstruct.library.event;
 
 import net.minecraftforge.fluids.FluidStack;
 
-import tconstruct.library.crafting.CastingRecipe;
 import cpw.mods.fml.common.eventhandler.Event;
+import tconstruct.library.crafting.CastingRecipe;
 
 /**
  * Fires when somebody tries to pour a liquid into a metal cast.

--- a/src/main/java/tconstruct/library/event/SmelteryCastedEvent.java
+++ b/src/main/java/tconstruct/library/event/SmelteryCastedEvent.java
@@ -2,8 +2,8 @@ package tconstruct.library.event;
 
 import net.minecraft.item.ItemStack;
 
-import tconstruct.library.crafting.CastingRecipe;
 import cpw.mods.fml.common.eventhandler.Event;
+import tconstruct.library.crafting.CastingRecipe;
 
 /**
  * Fired when an item is cast in the casting table. If consumeCast is set to true, the cast will be destroyed.

--- a/src/main/java/tconstruct/library/event/SmelteryEvent.java
+++ b/src/main/java/tconstruct/library/event/SmelteryEvent.java
@@ -1,12 +1,11 @@
 package tconstruct.library.event;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
 import cpw.mods.fml.common.eventhandler.Cancelable;
 import cpw.mods.fml.common.eventhandler.Event;
+import mantle.blocks.abstracts.InventoryLogic;
 
 public class SmelteryEvent extends Event {
 

--- a/src/main/java/tconstruct/library/event/ToolCraftEvent.java
+++ b/src/main/java/tconstruct/library/event/ToolCraftEvent.java
@@ -3,9 +3,9 @@ package tconstruct.library.event;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import cpw.mods.fml.common.eventhandler.Event;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.library.tools.ToolMaterial;
-import cpw.mods.fml.common.eventhandler.Event;
 
 /*
  * This event fires after all of the other construction. The resulting nbttag is added to the tool Note: The tag is the

--- a/src/main/java/tconstruct/library/tools/AbilityHelper.java
+++ b/src/main/java/tconstruct/library/tools/AbilityHelper.java
@@ -27,14 +27,14 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
 
+import cofh.api.energy.IEnergyContainerItem;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.eventhandler.Event.Result;
 import tconstruct.TConstruct;
 import tconstruct.library.ActiveToolMod;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.util.PiercingEntityDamage;
 import tconstruct.modifiers.tools.ModMoss;
-import cofh.api.energy.IEnergyContainerItem;
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.eventhandler.Event.Result;
 
 public class AbilityHelper {
 

--- a/src/main/java/tconstruct/library/tools/DualMaterialToolPart.java
+++ b/src/main/java/tconstruct/library/tools/DualMaterialToolPart.java
@@ -10,12 +10,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.util.TextureHelper;
 import tconstruct.tools.TinkerTools;
 import tconstruct.util.config.PHConstruct;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class DualMaterialToolPart extends DynamicToolPart {
 

--- a/src/main/java/tconstruct/library/tools/DynamicToolPart.java
+++ b/src/main/java/tconstruct/library/tools/DynamicToolPart.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
@@ -13,12 +11,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.items.abstracts.CraftingItem;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.util.IToolPart;
 import tconstruct.library.util.TextureHelper;
 import tconstruct.util.config.PHConstruct;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class DynamicToolPart extends CraftingItem implements IToolPart {
 

--- a/src/main/java/tconstruct/library/tools/FletchlingLeafMaterial.java
+++ b/src/main/java/tconstruct/library/tools/FletchlingLeafMaterial.java
@@ -1,9 +1,9 @@
 package tconstruct.library.tools;
 
-import mantle.blocks.BlockUtils;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
+
+import mantle.blocks.BlockUtils;
 
 public class FletchlingLeafMaterial extends FletchingMaterial {
 

--- a/src/main/java/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/tconstruct/library/tools/ToolCore.java
@@ -17,6 +17,11 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import cofh.api.energy.IEnergyContainerItem;
+import cofh.core.item.IEqualityOverrideItem;
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.ActiveToolMod;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
@@ -27,11 +32,6 @@ import tconstruct.tools.TinkerTools;
 import tconstruct.tools.entity.FancyEntityItem;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.weaponry.TinkerWeaponry;
-import cofh.api.energy.IEnergyContainerItem;
-import cofh.core.item.IEqualityOverrideItem;
-import cpw.mods.fml.common.Optional;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 /**
  * NBTTags Main tag - InfiTool

--- a/src/main/java/tconstruct/library/tools/Weapon.java
+++ b/src/main/java/tconstruct/library/tools/Weapon.java
@@ -1,8 +1,5 @@
 package tconstruct.library.tools;
 
-import mods.battlegear2.api.PlayerEventChild;
-import mods.battlegear2.api.weapons.IBattlegearWeapon;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -13,10 +10,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
-import tconstruct.tools.TinkerTools;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mods.battlegear2.api.PlayerEventChild;
+import mods.battlegear2.api.weapons.IBattlegearWeapon;
+import tconstruct.tools.TinkerTools;
 
 @Optional.InterfaceList({
         @Optional.Interface(modid = "battlegear2", iface = "mods.battlegear2.api.weapons.IBattlegearWeapon"),

--- a/src/main/java/tconstruct/library/weaponry/AmmoItem.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoItem.java
@@ -1,19 +1,18 @@
 package tconstruct.library.weaponry;
 
-import mods.battlegear2.api.PlayerEventChild;
-import mods.battlegear2.api.weapons.IBattlegearWeapon;
-
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import mods.battlegear2.api.PlayerEventChild;
+import mods.battlegear2.api.weapons.IBattlegearWeapon;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.tools.TinkerTools;
-import cpw.mods.fml.common.Optional;
-import cpw.mods.fml.relauncher.Side;
 
 @Optional.InterfaceList({
         @Optional.Interface(modid = "battlegear2", iface = "mods.battlegear2.api.weapons.IBattlegearWeapon") })

--- a/src/main/java/tconstruct/library/weaponry/AmmoWeapon.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoWeapon.java
@@ -1,8 +1,5 @@
 package tconstruct.library.weaponry;
 
-import mods.battlegear2.api.PlayerEventChild;
-import mods.battlegear2.api.weapons.IBattlegearWeapon;
-
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumAction;
@@ -10,11 +7,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
-import tconstruct.tools.TinkerTools;
-import tconstruct.weaponry.client.CrosshairType;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mods.battlegear2.api.PlayerEventChild;
+import mods.battlegear2.api.weapons.IBattlegearWeapon;
+import tconstruct.tools.TinkerTools;
+import tconstruct.weaponry.client.CrosshairType;
 
 @Optional.InterfaceList({
         @Optional.Interface(modid = "battlegear2", iface = "mods.battlegear2.api.weapons.IBattlegearWeapon") })

--- a/src/main/java/tconstruct/library/weaponry/BowBaseAmmo.java
+++ b/src/main/java/tconstruct/library/weaponry/BowBaseAmmo.java
@@ -2,8 +2,6 @@ package tconstruct.library.weaponry;
 
 import java.util.List;
 
-import mods.battlegear2.api.core.InventoryPlayerBattle;
-
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
@@ -14,13 +12,14 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.Loader;
+import mods.battlegear2.api.core.InventoryPlayerBattle;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.tools.BowstringMaterial;
 import tconstruct.library.tools.CustomMaterial;
 import tconstruct.weaponry.ammo.ArrowAmmo;
 import tconstruct.weaponry.entity.ArrowEntity;
-import cpw.mods.fml.common.Loader;
 
 public abstract class BowBaseAmmo extends ProjectileWeapon {
 

--- a/src/main/java/tconstruct/library/weaponry/ProjectileWeapon.java
+++ b/src/main/java/tconstruct/library/weaponry/ProjectileWeapon.java
@@ -4,9 +4,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import mods.battlegear2.api.PlayerEventChild;
-import mods.battlegear2.api.weapons.IBattlegearWeapon;
-
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -21,6 +18,11 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.ArrowLooseEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mods.battlegear2.api.PlayerEventChild;
+import mods.battlegear2.api.weapons.IBattlegearWeapon;
 import tconstruct.client.TProxyClient;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.AbilityHelper;
@@ -30,9 +32,6 @@ import tconstruct.modifiers.tools.ModMoss;
 import tconstruct.tools.TinkerTools;
 import tconstruct.weaponry.TinkerWeaponry;
 import tconstruct.weaponry.client.CrosshairType;
-import cpw.mods.fml.common.Optional;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 @Optional.InterfaceList({
         @Optional.Interface(modid = "battlegear2", iface = "mods.battlegear2.api.weapons.IBattlegearWeapon") })

--- a/src/main/java/tconstruct/mechworks/MechworksProxyClient.java
+++ b/src/main/java/tconstruct/mechworks/MechworksProxyClient.java
@@ -5,6 +5,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.client.registry.RenderingRegistry;
 import tconstruct.client.entity.item.ExplosiveRender;
 import tconstruct.common.TProxyCommon;
 import tconstruct.mechworks.entity.item.EntityLandmineFirework;
@@ -12,7 +13,6 @@ import tconstruct.mechworks.entity.item.ExplosivePrimed;
 import tconstruct.mechworks.gui.GuiLandmine;
 import tconstruct.mechworks.inventory.ContainerLandmine;
 import tconstruct.mechworks.logic.TileEntityLandmine;
-import cpw.mods.fml.client.registry.RenderingRegistry;
 
 public class MechworksProxyClient extends MechworksProxyCommon {
 

--- a/src/main/java/tconstruct/mechworks/MechworksProxyCommon.java
+++ b/src/main/java/tconstruct/mechworks/MechworksProxyCommon.java
@@ -3,10 +3,10 @@ package tconstruct.mechworks;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.network.IGuiHandler;
 import tconstruct.common.TProxyCommon;
 import tconstruct.mechworks.inventory.ContainerLandmine;
 import tconstruct.mechworks.logic.TileEntityLandmine;
-import cpw.mods.fml.common.network.IGuiHandler;
 
 public class MechworksProxyCommon implements IGuiHandler {
 

--- a/src/main/java/tconstruct/mechworks/TinkerMechworks.java
+++ b/src/main/java/tconstruct/mechworks/TinkerMechworks.java
@@ -1,8 +1,5 @@
 package tconstruct.mechworks;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
@@ -10,13 +7,6 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
-import tconstruct.TConstruct;
-import tconstruct.mechworks.blocks.BlockLandmine;
-import tconstruct.mechworks.entity.item.EntityLandmineFirework;
-import tconstruct.mechworks.entity.item.ExplosivePrimed;
-import tconstruct.mechworks.itemblocks.ItemBlockLandmine;
-import tconstruct.mechworks.logic.TileEntityLandmine;
-import tconstruct.tools.TinkerTools;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -24,6 +14,15 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.registry.EntityRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
+import tconstruct.TConstruct;
+import tconstruct.mechworks.blocks.BlockLandmine;
+import tconstruct.mechworks.entity.item.EntityLandmineFirework;
+import tconstruct.mechworks.entity.item.ExplosivePrimed;
+import tconstruct.mechworks.itemblocks.ItemBlockLandmine;
+import tconstruct.mechworks.logic.TileEntityLandmine;
+import tconstruct.tools.TinkerTools;
 
 @ObjectHolder(TConstruct.modID)
 // TODO handle migration of all items/blocks that were owned by the previously seperate mod

--- a/src/main/java/tconstruct/mechworks/blocks/BlockLandmine.java
+++ b/src/main/java/tconstruct/mechworks/blocks/BlockLandmine.java
@@ -6,9 +6,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
-import mantle.blocks.BlockUtils;
-import mantle.world.WorldHelper;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.BlockPressurePlate.Sensitivity;
@@ -33,14 +30,16 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.BlockUtils;
+import mantle.world.WorldHelper;
 import tconstruct.TConstruct;
 import tconstruct.mechworks.MechworksProxyCommon;
 import tconstruct.mechworks.landmine.Helper;
 import tconstruct.mechworks.logic.LandmineExplodeLogic;
 import tconstruct.mechworks.logic.TileEntityLandmine;
 import tconstruct.world.model.RenderLandmine;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 /**
  *

--- a/src/main/java/tconstruct/mechworks/entity/item/EntityLandmineFirework.java
+++ b/src/main/java/tconstruct/mechworks/entity/item/EntityLandmineFirework.java
@@ -6,9 +6,9 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
-import tconstruct.util.DamageSourceFireworkExplode;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.util.DamageSourceFireworkExplode;
 
 public class EntityLandmineFirework extends Entity {
 

--- a/src/main/java/tconstruct/mechworks/entity/item/ExplosivePrimed.java
+++ b/src/main/java/tconstruct/mechworks/entity/item/ExplosivePrimed.java
@@ -7,9 +7,9 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 
-import tconstruct.world.MiningExplosion;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.world.MiningExplosion;
 
 public class ExplosivePrimed extends Entity {
 

--- a/src/main/java/tconstruct/mechworks/landmine/behavior/BehaviorBlockThrow.java
+++ b/src/main/java/tconstruct/mechworks/landmine/behavior/BehaviorBlockThrow.java
@@ -1,11 +1,11 @@
 package tconstruct.mechworks.landmine.behavior;
 
-import mantle.blocks.BlockUtils;
-
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
+import mantle.blocks.BlockUtils;
 
 /**
  *

--- a/src/main/java/tconstruct/mechworks/logic/LandmineExplodeLogic.java
+++ b/src/main/java/tconstruct/mechworks/logic/LandmineExplodeLogic.java
@@ -3,12 +3,11 @@ package tconstruct.mechworks.logic;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-import mantle.world.WorldHelper;
-
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import mantle.world.WorldHelper;
 import tconstruct.mechworks.landmine.behavior.Behavior;
 
 /**

--- a/src/main/java/tconstruct/mechworks/model/CartRender.java
+++ b/src/main/java/tconstruct/mechworks/model/CartRender.java
@@ -11,9 +11,9 @@ import net.minecraft.util.Vec3;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.world.entity.CartEntity;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.world.entity.CartEntity;
 
 @SideOnly(Side.CLIENT)
 public class CartRender extends Render {

--- a/src/main/java/tconstruct/modifiers/tools/ModFlux.java
+++ b/src/main/java/tconstruct/modifiers/tools/ModFlux.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import tconstruct.library.tools.ToolCore;
 import cofh.api.energy.IEnergyContainerItem;
+import tconstruct.library.tools.ToolCore;
 
 /* TE3 support */
 

--- a/src/main/java/tconstruct/plugins/TinkerThaumcraft.java
+++ b/src/main/java/tconstruct/plugins/TinkerThaumcraft.java
@@ -1,18 +1,17 @@
 package tconstruct.plugins;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.item.ItemStack;
 
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLInterModComms;
+import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.library.crafting.ModifyBuilder;
 import tconstruct.modifiers.armor.AModThaumicVision;
 import tconstruct.world.TinkerWorld;
 import thaumcraft.api.ItemApi;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLInterModComms;
-import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(

--- a/src/main/java/tconstruct/plugins/fmp/TinkerFMP.java
+++ b/src/main/java/tconstruct/plugins/fmp/TinkerFMP.java
@@ -1,13 +1,13 @@
 package tconstruct.plugins.fmp;
 
+import codechicken.microblock.BlockMicroMaterial;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
 import mantle.pulsar.pulse.Handler;
 import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.tools.TinkerTools;
 import tconstruct.world.TinkerWorld;
-import codechicken.microblock.BlockMicroMaterial;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
 
 @Pulse(
         id = "Tinkers FMP Compatibility",

--- a/src/main/java/tconstruct/plugins/gears/TinkerGears.java
+++ b/src/main/java/tconstruct/plugins/gears/TinkerGears.java
@@ -2,9 +2,6 @@ package tconstruct.plugins.gears;
 
 import java.util.List;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
@@ -12,15 +9,17 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.FluidType;
 import tconstruct.library.crafting.Smeltery;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.util.config.PHConstruct;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
 
 @Pulse(
         id = "Tinkers Gears",

--- a/src/main/java/tconstruct/plugins/ic2/TinkerIC2.java
+++ b/src/main/java/tconstruct/plugins/ic2/TinkerIC2.java
@@ -1,19 +1,18 @@
 package tconstruct.plugins.ic2;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.LiquidCasting;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(

--- a/src/main/java/tconstruct/plugins/imc/TinkerAE2.java
+++ b/src/main/java/tconstruct/plugins/imc/TinkerAE2.java
@@ -3,12 +3,12 @@ package tconstruct.plugins.imc;
 import java.util.Arrays;
 import java.util.List;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-import tconstruct.TConstruct;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
+import tconstruct.TConstruct;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(

--- a/src/main/java/tconstruct/plugins/imc/TinkerBuildCraft.java
+++ b/src/main/java/tconstruct/plugins/imc/TinkerBuildCraft.java
@@ -1,15 +1,14 @@
 package tconstruct.plugins.imc;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
-import tconstruct.TConstruct;
-import tconstruct.smeltery.TinkerSmeltery;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
+import tconstruct.TConstruct;
+import tconstruct.smeltery.TinkerSmeltery;
 
 @Pulse(
         id = "Tinkers BuildCraft Compatibility",

--- a/src/main/java/tconstruct/plugins/imc/TinkerMystcraft.java
+++ b/src/main/java/tconstruct/plugins/imc/TinkerMystcraft.java
@@ -2,14 +2,13 @@ package tconstruct.plugins.imc;
 
 import static tconstruct.smeltery.TinkerSmeltery.*;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraftforge.fluids.Fluid;
 
-import tconstruct.TConstruct;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
+import tconstruct.TConstruct;
 
 @Pulse(
         id = "Tinkers Mystcraft Compatibility",

--- a/src/main/java/tconstruct/plugins/imc/TinkerRfTools.java
+++ b/src/main/java/tconstruct/plugins/imc/TinkerRfTools.java
@@ -2,14 +2,13 @@ package tconstruct.plugins.imc;
 
 import static tconstruct.smeltery.TinkerSmeltery.*;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraftforge.fluids.Fluid;
 
-import tconstruct.world.TinkerWorld;
 import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
+import tconstruct.world.TinkerWorld;
 
 @Pulse(id = "Tinkers RF-Tools Compatibility", forced = true, modsRequired = TinkerRfTools.modid)
 public class TinkerRfTools {

--- a/src/main/java/tconstruct/plugins/mfr/TinkerMFR.java
+++ b/src/main/java/tconstruct/plugins/mfr/TinkerMFR.java
@@ -1,10 +1,10 @@
 package tconstruct.plugins.mfr;
 
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 import mantle.pulsar.pulse.Handler;
 import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(

--- a/src/main/java/tconstruct/plugins/nei/BeltToggleFromGuiInputHandler.java
+++ b/src/main/java/tconstruct/plugins/nei/BeltToggleFromGuiInputHandler.java
@@ -2,11 +2,11 @@ package tconstruct.plugins.nei;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
 
-import tconstruct.client.ArmorControls;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.api.API;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.guihook.IContainerInputHandler;
+import tconstruct.client.ArmorControls;
 
 public class BeltToggleFromGuiInputHandler implements IContainerInputHandler {
 

--- a/src/main/java/tconstruct/plugins/nei/CraftingStationOverlayHandler.java
+++ b/src/main/java/tconstruct/plugins/nei/CraftingStationOverlayHandler.java
@@ -3,11 +3,11 @@ package tconstruct.plugins.nei;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.inventory.Slot;
 
+import codechicken.nei.recipe.DefaultOverlayHandler;
+import codechicken.nei.recipe.IRecipeHandler;
 import tconstruct.tools.gui.CraftingStationGui;
 import tconstruct.tools.inventory.CraftingStationContainer;
 import tconstruct.tools.logic.CraftingStationLogic;
-import codechicken.nei.recipe.DefaultOverlayHandler;
-import codechicken.nei.recipe.IRecipeHandler;
 
 /**
  * Modified copy of DefaultOverlayHandler from NotEnoughItems

--- a/src/main/java/tconstruct/plugins/nei/CraftingStationStackPositioner.java
+++ b/src/main/java/tconstruct/plugins/nei/CraftingStationStackPositioner.java
@@ -4,11 +4,11 @@ import java.util.ArrayList;
 
 import net.minecraft.client.Minecraft;
 
-import tconstruct.TConstruct;
-import tconstruct.tools.gui.CraftingStationGui;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.IStackPositioner;
 import codechicken.nei.recipe.GuiRecipe;
+import tconstruct.TConstruct;
+import tconstruct.tools.gui.CraftingStationGui;
 
 public class CraftingStationStackPositioner implements IStackPositioner {
 

--- a/src/main/java/tconstruct/plugins/nei/NEITConstructConfig.java
+++ b/src/main/java/tconstruct/plugins/nei/NEITConstructConfig.java
@@ -1,8 +1,8 @@
 package tconstruct.plugins.nei;
 
-import tconstruct.tools.gui.CraftingStationGui;
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
+import tconstruct.tools.gui.CraftingStationGui;
 
 public class NEITConstructConfig implements IConfigureNEI {
 

--- a/src/main/java/tconstruct/plugins/nei/RecipeHandlerAlloying.java
+++ b/src/main/java/tconstruct/plugins/nei/RecipeHandlerAlloying.java
@@ -10,10 +10,10 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.library.crafting.AlloyMix;
-import tconstruct.library.crafting.Smeltery;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.PositionedStack;
+import tconstruct.library.crafting.AlloyMix;
+import tconstruct.library.crafting.Smeltery;
 
 public class RecipeHandlerAlloying extends RecipeHandlerBase {
 

--- a/src/main/java/tconstruct/plugins/nei/RecipeHandlerCastingBase.java
+++ b/src/main/java/tconstruct/plugins/nei/RecipeHandlerCastingBase.java
@@ -7,9 +7,9 @@ import java.util.List;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import tconstruct.library.crafting.CastingRecipe;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
+import tconstruct.library.crafting.CastingRecipe;
 
 public abstract class RecipeHandlerCastingBase extends RecipeHandlerBase {
 

--- a/src/main/java/tconstruct/plugins/nei/RecipeHandlerCastingBasin.java
+++ b/src/main/java/tconstruct/plugins/nei/RecipeHandlerCastingBasin.java
@@ -7,10 +7,10 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
+import codechicken.lib.gui.GuiDraw;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.CastingRecipe;
 import tconstruct.library.crafting.LiquidCasting;
-import codechicken.lib.gui.GuiDraw;
 
 public class RecipeHandlerCastingBasin extends RecipeHandlerCastingBase {
 

--- a/src/main/java/tconstruct/plugins/nei/RecipeHandlerCastingTable.java
+++ b/src/main/java/tconstruct/plugins/nei/RecipeHandlerCastingTable.java
@@ -7,10 +7,10 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
+import codechicken.lib.gui.GuiDraw;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.CastingRecipe;
 import tconstruct.library.crafting.LiquidCasting;
-import codechicken.lib.gui.GuiDraw;
 
 public class RecipeHandlerCastingTable extends RecipeHandlerCastingBase {
 

--- a/src/main/java/tconstruct/plugins/nei/RecipeHandlerDryingRack.java
+++ b/src/main/java/tconstruct/plugins/nei/RecipeHandlerDryingRack.java
@@ -7,11 +7,11 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.library.crafting.DryingRackRecipes;
-import tconstruct.library.crafting.DryingRackRecipes.DryingRecipe;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
+import tconstruct.library.crafting.DryingRackRecipes;
+import tconstruct.library.crafting.DryingRackRecipes.DryingRecipe;
 
 public class RecipeHandlerDryingRack extends RecipeHandlerBase {
 

--- a/src/main/java/tconstruct/plugins/nei/RecipeHandlerMelting.java
+++ b/src/main/java/tconstruct/plugins/nei/RecipeHandlerMelting.java
@@ -5,18 +5,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 
-import mantle.utils.ItemMetaWrapper;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.library.crafting.Smeltery;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
+import mantle.utils.ItemMetaWrapper;
+import tconstruct.library.crafting.Smeltery;
 
 public class RecipeHandlerMelting extends RecipeHandlerBase {
 

--- a/src/main/java/tconstruct/plugins/nei/RecipeHandlerToolMaterials.java
+++ b/src/main/java/tconstruct/plugins/nei/RecipeHandlerToolMaterials.java
@@ -10,6 +10,8 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
+import codechicken.lib.gui.GuiDraw;
+import codechicken.nei.PositionedStack;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.CastingRecipe;
 import tconstruct.library.crafting.PatternBuilder;
@@ -23,8 +25,6 @@ import tconstruct.library.util.HarvestLevels;
 import tconstruct.library.util.IToolPart;
 import tconstruct.tools.items.ToolPart;
 import tconstruct.util.config.PHConstruct;
-import codechicken.lib.gui.GuiDraw;
-import codechicken.nei.PositionedStack;
 
 public class RecipeHandlerToolMaterials extends RecipeHandlerBase {
 

--- a/src/main/java/tconstruct/plugins/te4/TinkerTE4.java
+++ b/src/main/java/tconstruct/plugins/te4/TinkerTE4.java
@@ -1,8 +1,5 @@
 package tconstruct.plugins.te4;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -12,14 +9,16 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.tools.TinkerTools;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(

--- a/src/main/java/tconstruct/plugins/te4/TinkersThermalFoundation.java
+++ b/src/main/java/tconstruct/plugins/te4/TinkersThermalFoundation.java
@@ -1,8 +1,5 @@
 package tconstruct.plugins.te4;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -11,14 +8,16 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.library.crafting.FluidType;
 import tconstruct.library.crafting.Smeltery;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
 
 @GameRegistry.ObjectHolder(TinkersThermalFoundation.TF_MOD_ID)
 @Pulse(

--- a/src/main/java/tconstruct/plugins/ubc/TinkerUBC.java
+++ b/src/main/java/tconstruct/plugins/ubc/TinkerUBC.java
@@ -1,12 +1,12 @@
 package tconstruct.plugins.ubc;
 
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import exterminatorJeff.undergroundBiomes.api.UBAPIHook;
+import exterminatorJeff.undergroundBiomes.api.UBOreTexturizer.BlocksAreAlreadySet;
 import mantle.pulsar.pulse.Handler;
 import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import exterminatorJeff.undergroundBiomes.api.UBAPIHook;
-import exterminatorJeff.undergroundBiomes.api.UBOreTexturizer.BlocksAreAlreadySet;
 
 @Pulse(
         id = "Tinkers' Underground Biomes Compatiblity",

--- a/src/main/java/tconstruct/plugins/waila/BasinDataProvider.java
+++ b/src/main/java/tconstruct/plugins/waila/BasinDataProvider.java
@@ -2,11 +2,6 @@ package tconstruct.plugins.waila;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-import mcp.mobius.waila.api.IWailaDataProvider;
-import mcp.mobius.waila.api.SpecialChars;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -15,6 +10,10 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.api.SpecialChars;
 import tconstruct.smeltery.logic.CastingBasinLogic;
 
 public class BasinDataProvider implements IWailaDataProvider {

--- a/src/main/java/tconstruct/plugins/waila/CastingChannelDataProvider.java
+++ b/src/main/java/tconstruct/plugins/waila/CastingChannelDataProvider.java
@@ -2,11 +2,6 @@ package tconstruct.plugins.waila;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-import mcp.mobius.waila.api.IWailaDataProvider;
-import mcp.mobius.waila.api.SpecialChars;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -17,6 +12,10 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.api.SpecialChars;
 import tconstruct.smeltery.logic.CastingChannelLogic;
 
 public class CastingChannelDataProvider implements IWailaDataProvider {

--- a/src/main/java/tconstruct/plugins/waila/SearedTankDataProvider.java
+++ b/src/main/java/tconstruct/plugins/waila/SearedTankDataProvider.java
@@ -2,11 +2,6 @@ package tconstruct.plugins.waila;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-import mcp.mobius.waila.api.IWailaDataProvider;
-import mcp.mobius.waila.api.SpecialChars;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -15,6 +10,10 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.api.SpecialChars;
 import tconstruct.smeltery.logic.LavaTankLogic;
 
 public class SearedTankDataProvider implements IWailaDataProvider {

--- a/src/main/java/tconstruct/plugins/waila/SmelteryDataProvider.java
+++ b/src/main/java/tconstruct/plugins/waila/SmelteryDataProvider.java
@@ -2,11 +2,6 @@ package tconstruct.plugins.waila;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-import mcp.mobius.waila.api.IWailaDataProvider;
-import mcp.mobius.waila.api.SpecialChars;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -15,6 +10,10 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.api.SpecialChars;
 import tconstruct.smeltery.logic.SmelteryLogic;
 
 public class SmelteryDataProvider implements IWailaDataProvider {

--- a/src/main/java/tconstruct/plugins/waila/TableDataProvider.java
+++ b/src/main/java/tconstruct/plugins/waila/TableDataProvider.java
@@ -2,10 +2,6 @@ package tconstruct.plugins.waila;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-import mcp.mobius.waila.api.IWailaDataProvider;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -13,6 +9,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
 import tconstruct.smeltery.logic.CastingTableLogic;
 
 public class TableDataProvider implements IWailaDataProvider {

--- a/src/main/java/tconstruct/plugins/waila/TinkerWaila.java
+++ b/src/main/java/tconstruct/plugins/waila/TinkerWaila.java
@@ -1,11 +1,11 @@
 package tconstruct.plugins.waila;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-import tconstruct.TConstruct;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
+import tconstruct.TConstruct;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(

--- a/src/main/java/tconstruct/plugins/waila/WailaRegistrar.java
+++ b/src/main/java/tconstruct/plugins/waila/WailaRegistrar.java
@@ -1,9 +1,8 @@
 package tconstruct.plugins.waila;
 
-import mcp.mobius.waila.api.IWailaRegistrar;
-
 import net.minecraftforge.fluids.FluidStack;
 
+import mcp.mobius.waila.api.IWailaRegistrar;
 import tconstruct.TConstruct;
 import tconstruct.smeltery.blocks.LavaTankBlock;
 import tconstruct.smeltery.blocks.SmelteryBlock;

--- a/src/main/java/tconstruct/smeltery/SmelteryProxyClient.java
+++ b/src/main/java/tconstruct/smeltery/SmelteryProxyClient.java
@@ -1,8 +1,5 @@
 package tconstruct.smeltery;
 
-import mantle.client.MProxyClient;
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -14,6 +11,10 @@ import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fluids.RenderBlockFluid;
 
+import cpw.mods.fml.client.registry.ClientRegistry;
+import cpw.mods.fml.client.registry.RenderingRegistry;
+import mantle.client.MProxyClient;
+import mantle.lib.client.MantleClientRegistry;
 import tconstruct.armor.TinkerArmor;
 import tconstruct.armor.modelblock.DryingRackRender;
 import tconstruct.armor.modelblock.DryingRackSpecialRender;
@@ -26,8 +27,6 @@ import tconstruct.smeltery.logic.CastingTableLogic;
 import tconstruct.smeltery.logic.SmelteryLogic;
 import tconstruct.smeltery.model.*;
 import tconstruct.tools.TinkerTools;
-import cpw.mods.fml.client.registry.ClientRegistry;
-import cpw.mods.fml.client.registry.RenderingRegistry;
 
 public class SmelteryProxyClient extends SmelteryProxyCommon {
 

--- a/src/main/java/tconstruct/smeltery/SmelteryProxyCommon.java
+++ b/src/main/java/tconstruct/smeltery/SmelteryProxyCommon.java
@@ -1,13 +1,12 @@
 package tconstruct.smeltery;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import tconstruct.common.TProxyCommon;
 import cpw.mods.fml.common.network.IGuiHandler;
+import mantle.blocks.abstracts.InventoryLogic;
+import tconstruct.common.TProxyCommon;
 
 public class SmelteryProxyCommon implements IGuiHandler {
 

--- a/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
@@ -2,11 +2,6 @@ package tconstruct.smeltery;
 
 import java.util.*;
 
-import mantle.blocks.BlockUtils;
-import mantle.blocks.abstracts.MultiServantLogic;
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
@@ -26,6 +21,17 @@ import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.SidedProxy;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.blocks.BlockUtils;
+import mantle.blocks.abstracts.MultiServantLogic;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.CastingRecipe;
@@ -43,13 +49,6 @@ import tconstruct.tools.TinkerTools;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.world.TinkerWorld;
 import tconstruct.world.items.OreBerries;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.SidedProxy;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(id = "Tinkers' Smeltery", description = "Liquid metals, casting, and the multiblock structure.")

--- a/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
@@ -588,7 +588,7 @@ public class TinkerSmeltery {
         TConstructRegistry.addItemToDirectory("ceramicPattern", TinkerSmeltery.ceramicPattern);
         for (int i = 0; i < patternTypes.length; i++) {
             TConstructRegistry.addItemStackToDirectory(
-                    patternTypes[i] + "Cast",
+                    patternTypes[i] + "CastCeramic",
                     new ItemStack(TinkerSmeltery.ceramicPattern, 1, i));
         }
 

--- a/src/main/java/tconstruct/smeltery/TinkerSmelteryEvents.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmelteryEvents.java
@@ -1,7 +1,5 @@
 package tconstruct.smeltery;
 
-import mantle.world.WorldHelper;
-
 import net.minecraft.block.Block;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -9,14 +7,15 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition.MovingObjectType;
 import net.minecraftforge.event.entity.player.FillBucketEvent;
 
+import cpw.mods.fml.common.eventhandler.Event.Result;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent.ItemCraftedEvent;
+import mantle.world.WorldHelper;
 import tconstruct.armor.player.TPlayerStats;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.smeltery.blocks.LiquidMetalFinite;
 import tconstruct.tools.TinkerTools;
 import tconstruct.util.config.PHConstruct;
-import cpw.mods.fml.common.eventhandler.Event.Result;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.gameevent.PlayerEvent.ItemCraftedEvent;
 
 public class TinkerSmelteryEvents {
 

--- a/src/main/java/tconstruct/smeltery/blocks/CastingChannelBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/CastingChannelBlock.java
@@ -14,12 +14,12 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.smeltery.logic.CastingChannelLogic;
 import tconstruct.smeltery.model.BlockRenderCastingChannel;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 /**
  * @author BluSunrize

--- a/src/main/java/tconstruct/smeltery/blocks/GlassBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/GlassBlock.java
@@ -8,9 +8,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.blocks.TConstructBlock;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.blocks.TConstructBlock;
 
 public class GlassBlock extends TConstructBlock {
 

--- a/src/main/java/tconstruct/smeltery/blocks/GlassBlockConnected.java
+++ b/src/main/java/tconstruct/smeltery/blocks/GlassBlockConnected.java
@@ -1,7 +1,5 @@
 package tconstruct.smeltery.blocks;
 
-import mantle.blocks.MantleBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -10,10 +8,11 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.library.TConstructRegistry;
-import tconstruct.util.config.PHConstruct;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
+import tconstruct.library.TConstructRegistry;
+import tconstruct.util.config.PHConstruct;
 
 /**
  * @author fuj1n

--- a/src/main/java/tconstruct/smeltery/blocks/GlassBlockConnectedMeta.java
+++ b/src/main/java/tconstruct/smeltery/blocks/GlassBlockConnectedMeta.java
@@ -11,9 +11,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.util.config.PHConstruct;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.util.config.PHConstruct;
 
 /**
  * @author fuj1n

--- a/src/main/java/tconstruct/smeltery/blocks/GlassBlockStained.java
+++ b/src/main/java/tconstruct/smeltery/blocks/GlassBlockStained.java
@@ -6,9 +6,9 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-import tconstruct.blocks.TConstructBlock;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.blocks.TConstructBlock;
 
 public class GlassBlockStained extends TConstructBlock {
 

--- a/src/main/java/tconstruct/smeltery/blocks/GlassPaneConnected.java
+++ b/src/main/java/tconstruct/smeltery/blocks/GlassPaneConnected.java
@@ -12,10 +12,10 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import tconstruct.smeltery.model.PaneConnectedRender;
-import tconstruct.util.config.PHConstruct;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.smeltery.model.PaneConnectedRender;
+import tconstruct.util.config.PHConstruct;
 
 public class GlassPaneConnected extends GlassBlockConnected {
 

--- a/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
@@ -2,8 +2,6 @@ package tconstruct.smeltery.blocks;
 
 import java.util.List;
 
-import mantle.blocks.iface.IServantLogic;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
@@ -23,12 +21,13 @@ import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.iface.IServantLogic;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.smeltery.itemblocks.LavaTankItemBlock;
 import tconstruct.smeltery.logic.LavaTankLogic;
 import tconstruct.smeltery.model.TankRender;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class LavaTankBlock extends BlockContainer {
 

--- a/src/main/java/tconstruct/smeltery/blocks/LiquidMetalFinite.java
+++ b/src/main/java/tconstruct/smeltery/blocks/LiquidMetalFinite.java
@@ -10,10 +10,10 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.BlockFluidFinite;
 import net.minecraftforge.fluids.Fluid;
 
-import tconstruct.library.TConstructRegistry;
-import tconstruct.smeltery.TinkerSmeltery;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.library.TConstructRegistry;
+import tconstruct.smeltery.TinkerSmeltery;
 
 public class LiquidMetalFinite extends BlockFluidFinite {
 

--- a/src/main/java/tconstruct/smeltery/blocks/PaneBase.java
+++ b/src/main/java/tconstruct/smeltery/blocks/PaneBase.java
@@ -10,9 +10,9 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 
-import tconstruct.smeltery.model.PaneRender;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.smeltery.model.PaneRender;
 
 public class PaneBase extends BlockStainedGlassPane {
 

--- a/src/main/java/tconstruct/smeltery/blocks/SearedBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/SearedBlock.java
@@ -2,8 +2,6 @@ package tconstruct.smeltery.blocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.InventoryBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
@@ -16,6 +14,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryBlock;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.smeltery.logic.CastingBasinLogic;
@@ -23,8 +24,6 @@ import tconstruct.smeltery.logic.CastingBlockLogic;
 import tconstruct.smeltery.logic.CastingTableLogic;
 import tconstruct.smeltery.logic.FaucetLogic;
 import tconstruct.smeltery.model.CastingBlockRender;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class SearedBlock extends InventoryBlock {
 

--- a/src/main/java/tconstruct/smeltery/blocks/SearedSlab.java
+++ b/src/main/java/tconstruct/smeltery/blocks/SearedSlab.java
@@ -9,11 +9,11 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.blocks.SlabBase;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.smeltery.TinkerSmeltery;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class SearedSlab extends SlabBase {
 

--- a/src/main/java/tconstruct/smeltery/blocks/SmelteryBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/SmelteryBlock.java
@@ -3,12 +3,6 @@ package tconstruct.smeltery.blocks;
 import java.util.List;
 import java.util.Random;
 
-import mantle.blocks.abstracts.InventoryBlock;
-import mantle.blocks.abstracts.MultiServantLogic;
-import mantle.blocks.iface.IFacingLogic;
-import mantle.blocks.iface.IMasterLogic;
-import mantle.blocks.iface.IServantLogic;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
@@ -22,14 +16,19 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryBlock;
+import mantle.blocks.abstracts.MultiServantLogic;
+import mantle.blocks.iface.IFacingLogic;
+import mantle.blocks.iface.IMasterLogic;
+import mantle.blocks.iface.IServantLogic;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.smeltery.SmelteryProxyCommon;
 import tconstruct.smeltery.logic.SmelteryDrainLogic;
 import tconstruct.smeltery.logic.SmelteryLogic;
 import tconstruct.smeltery.model.SmelteryRender;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class SmelteryBlock extends InventoryBlock {
 

--- a/src/main/java/tconstruct/smeltery/blocks/SpeedBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/SpeedBlock.java
@@ -9,9 +9,9 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import tconstruct.blocks.TConstructBlock;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.blocks.TConstructBlock;
 
 public class SpeedBlock extends TConstructBlock {
 

--- a/src/main/java/tconstruct/smeltery/blocks/SpeedSlab.java
+++ b/src/main/java/tconstruct/smeltery/blocks/SpeedSlab.java
@@ -11,11 +11,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.blocks.SlabBase;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.smeltery.TinkerSmeltery;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class SpeedSlab extends SlabBase {
 

--- a/src/main/java/tconstruct/smeltery/blocks/TConstructFluid.java
+++ b/src/main/java/tconstruct/smeltery/blocks/TConstructFluid.java
@@ -6,9 +6,9 @@ import net.minecraft.util.IIcon;
 import net.minecraftforge.fluids.BlockFluidClassic;
 import net.minecraftforge.fluids.Fluid;
 
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.library.TConstructRegistry;
 
 public class TConstructFluid extends BlockFluidClassic {
 

--- a/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
+++ b/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
@@ -18,12 +18,12 @@ import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
+import cpw.mods.fml.common.Loader;
 import tconstruct.TConstruct;
 import tconstruct.smeltery.inventory.ActiveContainer;
 import tconstruct.smeltery.inventory.SmelteryContainer;
 import tconstruct.smeltery.logic.SmelteryLogic;
 import tconstruct.util.network.SmelteryPacket;
-import cpw.mods.fml.common.Loader;
 
 public class SmelteryGui extends ActiveContainerGui {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/CastingChannelItem.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/CastingChannelItem.java
@@ -1,8 +1,8 @@
 package tconstruct.smeltery.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class CastingChannelItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/GlassBlockItem.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/GlassBlockItem.java
@@ -2,12 +2,12 @@ package tconstruct.smeltery.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class GlassBlockItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/GlassPaneItem.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/GlassPaneItem.java
@@ -1,8 +1,8 @@
 package tconstruct.smeltery.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class GlassPaneItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/LavaTankItemBlock.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/LavaTankItemBlock.java
@@ -2,8 +2,6 @@ package tconstruct.smeltery.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -12,6 +10,7 @@ import net.minecraft.util.StatCollector;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
+import mantle.blocks.abstracts.MultiItemBlock;
 import tconstruct.smeltery.logic.LavaTankLogic;
 
 public class LavaTankItemBlock extends MultiItemBlock implements IFluidContainerItem {

--- a/src/main/java/tconstruct/smeltery/itemblocks/MetalItemBlock.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/MetalItemBlock.java
@@ -2,12 +2,12 @@ package tconstruct.smeltery.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class MetalItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/SearedSlabItem.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/SearedSlabItem.java
@@ -1,8 +1,8 @@
 package tconstruct.smeltery.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class SearedSlabItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/SearedTableItemBlock.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/SearedTableItemBlock.java
@@ -2,12 +2,12 @@ package tconstruct.smeltery.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class SearedTableItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/SmelteryItemBlock.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/SmelteryItemBlock.java
@@ -2,17 +2,16 @@ package tconstruct.smeltery.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import tconstruct.achievements.TAchievements;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.MultiItemBlock;
+import tconstruct.achievements.TAchievements;
 
 public class SmelteryItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/SpeedBlockItem.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/SpeedBlockItem.java
@@ -2,12 +2,12 @@ package tconstruct.smeltery.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class SpeedBlockItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/SpeedSlabItem.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/SpeedSlabItem.java
@@ -2,12 +2,12 @@ package tconstruct.smeltery.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class SpeedSlabItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/StainedGlassClearItem.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/StainedGlassClearItem.java
@@ -1,8 +1,8 @@
 package tconstruct.smeltery.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class StainedGlassClearItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/itemblocks/StainedGlassClearPaneItem.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/StainedGlassClearPaneItem.java
@@ -1,8 +1,8 @@
 package tconstruct.smeltery.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class StainedGlassClearPaneItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/smeltery/items/FilledBucket.java
+++ b/src/main/java/tconstruct/smeltery/items/FilledBucket.java
@@ -2,8 +2,6 @@ package tconstruct.smeltery.items;
 
 import java.util.List;
 
-import mantle.world.WorldHelper;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
@@ -18,10 +16,11 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.BlockFluidFinite;
 
-import tconstruct.TConstruct;
-import tconstruct.smeltery.TinkerSmeltery;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.world.WorldHelper;
+import tconstruct.TConstruct;
+import tconstruct.smeltery.TinkerSmeltery;
 
 public class FilledBucket extends ItemBucket {
 

--- a/src/main/java/tconstruct/smeltery/logic/CastingBlockLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/CastingBlockLogic.java
@@ -1,7 +1,5 @@
 package tconstruct.smeltery.logic;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
@@ -16,6 +14,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
 
+import cpw.mods.fml.common.eventhandler.Event;
+import mantle.blocks.abstracts.InventoryLogic;
 import tconstruct.TConstruct;
 import tconstruct.library.crafting.CastingRecipe;
 import tconstruct.library.crafting.LiquidCasting;
@@ -24,7 +24,6 @@ import tconstruct.library.event.SmelteryCastedEvent;
 import tconstruct.library.event.SmelteryEvent;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.library.util.IPattern;
-import cpw.mods.fml.common.eventhandler.Event;
 
 public abstract class CastingBlockLogic extends InventoryLogic implements IFluidTank, IFluidHandler, ISidedInventory {
 

--- a/src/main/java/tconstruct/smeltery/logic/CastingChannelLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/CastingChannelLogic.java
@@ -13,9 +13,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
 
-import tconstruct.TConstruct;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.TConstruct;
 
 /**
  * @author BluSunrize

--- a/src/main/java/tconstruct/smeltery/logic/FaucetLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/FaucetLogic.java
@@ -1,8 +1,5 @@
 package tconstruct.smeltery.logic;
 
-import mantle.blocks.iface.IActiveLogic;
-import mantle.blocks.iface.IFacingLogic;
-
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
@@ -15,6 +12,8 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import mantle.blocks.iface.IActiveLogic;
+import mantle.blocks.iface.IFacingLogic;
 import tconstruct.TConstruct;
 
 public class FaucetLogic extends TileEntity implements IFacingLogic, IActiveLogic, IFluidHandler {

--- a/src/main/java/tconstruct/smeltery/logic/LavaTankLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/LavaTankLogic.java
@@ -1,13 +1,13 @@
 package tconstruct.smeltery.logic;
 
-import mantle.blocks.abstracts.MultiServantLogic;
-
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
+
+import mantle.blocks.abstracts.MultiServantLogic;
 
 public class LavaTankLogic extends MultiServantLogic implements IFluidHandler {
 

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryDrainLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryDrainLogic.java
@@ -1,9 +1,5 @@
 package tconstruct.smeltery.logic;
 
-import mantle.blocks.abstracts.MultiServantLogic;
-import mantle.blocks.iface.IFacingLogic;
-import mantle.world.CoordTuple;
-
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
@@ -15,6 +11,10 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
+
+import mantle.blocks.abstracts.MultiServantLogic;
+import mantle.blocks.iface.IFacingLogic;
+import mantle.world.CoordTuple;
 
 public class SmelteryDrainLogic extends MultiServantLogic implements IFluidHandler, IFacingLogic {
 

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -4,14 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import mantle.blocks.abstracts.InventoryLogic;
-import mantle.blocks.abstracts.MultiServantLogic;
-import mantle.blocks.iface.IActiveLogic;
-import mantle.blocks.iface.IFacingLogic;
-import mantle.blocks.iface.IMasterLogic;
-import mantle.blocks.iface.IServantLogic;
-import mantle.world.CoordTuple;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -37,14 +29,21 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryLogic;
+import mantle.blocks.abstracts.MultiServantLogic;
+import mantle.blocks.iface.IActiveLogic;
+import mantle.blocks.iface.IFacingLogic;
+import mantle.blocks.iface.IMasterLogic;
+import mantle.blocks.iface.IServantLogic;
+import mantle.world.CoordTuple;
 import tconstruct.TConstruct;
 import tconstruct.library.crafting.Smeltery;
 import tconstruct.smeltery.SmelteryDamageSource;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.smeltery.inventory.SmelteryContainer;
 import tconstruct.util.config.PHConstruct;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 /*
  * Simple class for storing items in the block

--- a/src/main/java/tconstruct/smeltery/model/BlockRenderCastingChannel.java
+++ b/src/main/java/tconstruct/smeltery/model/BlockRenderCastingChannel.java
@@ -13,10 +13,10 @@ import net.minecraftforge.fluids.FluidTankInfo;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.client.BlockSkinRenderHelper;
-import tconstruct.smeltery.logic.CastingChannelLogic;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.client.BlockSkinRenderHelper;
+import tconstruct.smeltery.logic.CastingChannelLogic;
 
 /**
  * @author BluSunrize

--- a/src/main/java/tconstruct/smeltery/model/CastingBasinSpecialRender.java
+++ b/src/main/java/tconstruct/smeltery/model/CastingBasinSpecialRender.java
@@ -9,11 +9,11 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.ItemBlocklike;
 import tconstruct.smeltery.logic.CastingBasinLogic;
 import tconstruct.tools.entity.FancyEntityItem;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 /* Special renderer, only used for drawing tools */
 

--- a/src/main/java/tconstruct/smeltery/model/CastingBlockRender.java
+++ b/src/main/java/tconstruct/smeltery/model/CastingBlockRender.java
@@ -6,6 +6,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fluids.Fluid;
 
+import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import cpw.mods.fml.client.registry.RenderingRegistry;
 import tconstruct.TConstruct;
 import tconstruct.client.BlockSkinRenderHelper;
 import tconstruct.library.crafting.CastingRecipe;
@@ -14,8 +16,6 @@ import tconstruct.smeltery.logic.CastingBasinLogic;
 import tconstruct.smeltery.logic.CastingTableLogic;
 import tconstruct.smeltery.logic.FaucetLogic;
 import tconstruct.util.ItemHelper;
-import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
-import cpw.mods.fml.client.registry.RenderingRegistry;
 
 public class CastingBlockRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/smeltery/model/CastingTableSpecialRenderer.java
+++ b/src/main/java/tconstruct/smeltery/model/CastingTableSpecialRenderer.java
@@ -9,12 +9,12 @@ import net.minecraft.tileentity.TileEntity;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.ItemBlocklike;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.smeltery.logic.CastingTableLogic;
 import tconstruct.tools.entity.FancyEntityItem;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 /* Special renderer, only used for drawing tools */
 

--- a/src/main/java/tconstruct/smeltery/model/PaneConnectedRender.java
+++ b/src/main/java/tconstruct/smeltery/model/PaneConnectedRender.java
@@ -7,9 +7,9 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-import tconstruct.smeltery.blocks.GlassPaneConnected;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.smeltery.blocks.GlassPaneConnected;
 
 public class PaneConnectedRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/smeltery/model/PaneRender.java
+++ b/src/main/java/tconstruct/smeltery/model/PaneRender.java
@@ -4,9 +4,9 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
-import tconstruct.util.ItemHelper;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.util.ItemHelper;
 
 public class PaneRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/smeltery/model/SmelteryRender.java
+++ b/src/main/java/tconstruct/smeltery/model/SmelteryRender.java
@@ -1,7 +1,5 @@
 package tconstruct.smeltery.model;
 
-import mantle.world.CoordTuple;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
@@ -10,12 +8,13 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
+import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import cpw.mods.fml.client.registry.RenderingRegistry;
+import mantle.world.CoordTuple;
 import tconstruct.client.BlockSkinRenderHelper;
 import tconstruct.library.crafting.Smeltery;
 import tconstruct.smeltery.logic.SmelteryLogic;
 import tconstruct.util.ItemHelper;
-import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
-import cpw.mods.fml.client.registry.RenderingRegistry;
 
 public class SmelteryRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/smeltery/model/TankItemRenderer.java
+++ b/src/main/java/tconstruct/smeltery/model/TankItemRenderer.java
@@ -8,8 +8,8 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.util.ItemHelper;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.util.ItemHelper;
 
 public class TankItemRenderer implements IItemRenderer {
 

--- a/src/main/java/tconstruct/smeltery/model/TankRender.java
+++ b/src/main/java/tconstruct/smeltery/model/TankRender.java
@@ -10,11 +10,11 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import cpw.mods.fml.client.registry.RenderingRegistry;
 import tconstruct.client.BlockSkinRenderHelper;
 import tconstruct.smeltery.logic.LavaTankLogic;
 import tconstruct.util.ItemHelper;
-import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
-import cpw.mods.fml.client.registry.RenderingRegistry;
 
 public class TankRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/tools/TinkerToolEvents.java
+++ b/src/main/java/tconstruct/tools/TinkerToolEvents.java
@@ -22,6 +22,9 @@ import net.minecraftforge.event.entity.player.PlayerDropsEvent;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.OreDictionary.OreRegisterEvent;
 
+import cpw.mods.fml.common.eventhandler.Event.Result;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent.ItemCraftedEvent;
 import tconstruct.TConstruct;
 import tconstruct.armor.player.TPlayerStats;
 import tconstruct.library.TConstructRegistry;
@@ -33,9 +36,6 @@ import tconstruct.library.tools.*;
 import tconstruct.util.ItemHelper;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.util.network.MovementUpdatePacket;
-import cpw.mods.fml.common.eventhandler.Event.Result;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.gameevent.PlayerEvent.ItemCraftedEvent;
 
 public class TinkerToolEvents {
 

--- a/src/main/java/tconstruct/tools/TinkerTools.java
+++ b/src/main/java/tconstruct/tools/TinkerTools.java
@@ -2,10 +2,6 @@ package tconstruct.tools;
 
 import static net.minecraft.util.EnumChatFormatting.*;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-import mantle.utils.RecipeRemover;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockDispenser;
 import net.minecraft.block.material.Material;
@@ -20,6 +16,17 @@ import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.SidedProxy;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
+import mantle.utils.RecipeRemover;
 import tconstruct.TConstruct;
 import tconstruct.achievements.items.CraftAchievementItem;
 import tconstruct.common.itemblocks.MetadataItemBlock;
@@ -44,14 +51,6 @@ import tconstruct.world.TDispenserBehaviorSpawnEgg;
 import tconstruct.world.TinkerWorld;
 import tconstruct.world.blocks.SoilBlock;
 import tconstruct.world.itemblocks.CraftedSoilItemBlock;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.SidedProxy;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(
@@ -245,8 +244,9 @@ public class TinkerTools {
         for (int i = 1; i < patternTypes.length; i++) {
             TConstructRegistry
                     .addItemStackToDirectory(patternTypes[i] + "Pattern", new ItemStack(TinkerTools.woodPattern, 1, i));
-            TConstructRegistry
-                    .addItemStackToDirectory(patternTypes[i] + "PatternClay", new ItemStack(TinkerTools.clayPattern, 1, i));
+            TConstructRegistry.addItemStackToDirectory(
+                    patternTypes[i] + "PatternClay",
+                    new ItemStack(TinkerTools.clayPattern, 1, i));
         }
 
         TinkerTools.manualBook = new Manual();

--- a/src/main/java/tconstruct/tools/TinkerTools.java
+++ b/src/main/java/tconstruct/tools/TinkerTools.java
@@ -246,7 +246,7 @@ public class TinkerTools {
             TConstructRegistry
                     .addItemStackToDirectory(patternTypes[i] + "Pattern", new ItemStack(TinkerTools.woodPattern, 1, i));
             TConstructRegistry
-                    .addItemStackToDirectory(patternTypes[i] + "Pattern", new ItemStack(TinkerTools.clayPattern, 1, i));
+                    .addItemStackToDirectory(patternTypes[i] + "PatternClay", new ItemStack(TinkerTools.clayPattern, 1, i));
         }
 
         TinkerTools.manualBook = new Manual();

--- a/src/main/java/tconstruct/tools/ToolProxyClient.java
+++ b/src/main/java/tconstruct/tools/ToolProxyClient.java
@@ -2,9 +2,6 @@ package tconstruct.tools;
 
 import static tconstruct.tools.TinkerTools.*;
 
-import mantle.client.MProxyClient;
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -16,6 +13,10 @@ import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.client.event.sound.SoundLoadEvent;
 import net.minecraftforge.common.MinecraftForge;
 
+import cpw.mods.fml.client.registry.RenderingRegistry;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import mantle.client.MProxyClient;
+import mantle.lib.client.MantleClientRegistry;
 import tconstruct.TConstruct;
 import tconstruct.client.FlexibleToolRenderer;
 import tconstruct.client.entity.projectile.LaunchedItemRender;
@@ -38,8 +39,6 @@ import tconstruct.tools.logic.*;
 import tconstruct.tools.model.*;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.weaponry.TinkerWeaponry;
-import cpw.mods.fml.client.registry.RenderingRegistry;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class ToolProxyClient extends ToolProxyCommon {
 

--- a/src/main/java/tconstruct/tools/ToolProxyCommon.java
+++ b/src/main/java/tconstruct/tools/ToolProxyCommon.java
@@ -1,13 +1,12 @@
 package tconstruct.tools;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import tconstruct.common.TProxyCommon;
 import cpw.mods.fml.common.network.IGuiHandler;
+import mantle.blocks.abstracts.InventoryLogic;
+import tconstruct.common.TProxyCommon;
 
 public class ToolProxyCommon implements IGuiHandler {
 

--- a/src/main/java/tconstruct/tools/blocks/BattlesignBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/BattlesignBlock.java
@@ -13,10 +13,10 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.tools.logic.BattlesignLogic;
-import tconstruct.tools.model.BattlesignRender;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.tools.logic.BattlesignLogic;
+import tconstruct.tools.model.BattlesignRender;
 
 public class BattlesignBlock extends EquipBlock {
 

--- a/src/main/java/tconstruct/tools/blocks/CraftingSlab.java
+++ b/src/main/java/tconstruct/tools/blocks/CraftingSlab.java
@@ -2,8 +2,6 @@ package tconstruct.tools.blocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.InventorySlab;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
@@ -18,14 +16,15 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventorySlab;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.tools.TinkerTools;
 import tconstruct.tools.ToolProxyCommon;
 import tconstruct.tools.logic.*;
 import tconstruct.util.config.PHConstruct;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class CraftingSlab extends InventorySlab {
 

--- a/src/main/java/tconstruct/tools/blocks/CraftingStationBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/CraftingStationBlock.java
@@ -2,8 +2,6 @@ package tconstruct.tools.blocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.InventoryBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
@@ -15,13 +13,14 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryBlock;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.tools.ToolProxyCommon;
 import tconstruct.tools.logic.CraftingStationLogic;
 import tconstruct.tools.model.TableRender;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class CraftingStationBlock extends InventoryBlock {
 

--- a/src/main/java/tconstruct/tools/blocks/EquipBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/EquipBlock.java
@@ -2,8 +2,6 @@ package tconstruct.tools.blocks;
 
 import java.util.Random;
 
-import mantle.blocks.abstracts.InventoryBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -20,14 +18,15 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryBlock;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.tools.ToolProxyCommon;
 import tconstruct.tools.logic.EquipLogic;
 import tconstruct.tools.logic.FrypanLogic;
 import tconstruct.tools.model.FrypanRender;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class EquipBlock extends InventoryBlock {
 

--- a/src/main/java/tconstruct/tools/blocks/FurnaceSlab.java
+++ b/src/main/java/tconstruct/tools/blocks/FurnaceSlab.java
@@ -2,10 +2,6 @@ package tconstruct.tools.blocks;
 
 import java.util.Random;
 
-import mantle.blocks.abstracts.InventorySlab;
-import mantle.blocks.iface.IActiveLogic;
-import mantle.blocks.iface.IFacingLogic;
-
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -14,12 +10,15 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventorySlab;
+import mantle.blocks.iface.IActiveLogic;
+import mantle.blocks.iface.IFacingLogic;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.tools.ToolProxyCommon;
 import tconstruct.tools.logic.FurnaceLogic;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class FurnaceSlab extends InventorySlab {
 

--- a/src/main/java/tconstruct/tools/blocks/MultiBrick.java
+++ b/src/main/java/tconstruct/tools/blocks/MultiBrick.java
@@ -9,9 +9,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.blocks.TConstructBlock;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.blocks.TConstructBlock;
 
 public class MultiBrick extends TConstructBlock {
 

--- a/src/main/java/tconstruct/tools/blocks/MultiBrickFancy.java
+++ b/src/main/java/tconstruct/tools/blocks/MultiBrickFancy.java
@@ -9,9 +9,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.blocks.TConstructBlock;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.blocks.TConstructBlock;
 
 public class MultiBrickFancy extends TConstructBlock {
 

--- a/src/main/java/tconstruct/tools/blocks/MultiBrickMetal.java
+++ b/src/main/java/tconstruct/tools/blocks/MultiBrickMetal.java
@@ -5,9 +5,9 @@ import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.util.IIcon;
 
-import tconstruct.blocks.TConstructBlock;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.blocks.TConstructBlock;
 
 public class MultiBrickMetal extends TConstructBlock {
 

--- a/src/main/java/tconstruct/tools/blocks/ToolBenchBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/ToolBenchBlock.java
@@ -2,8 +2,6 @@ package tconstruct.tools.blocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.InventoryBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
@@ -20,6 +18,9 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryBlock;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.tools.TinkerTools;
@@ -27,8 +28,6 @@ import tconstruct.tools.ToolProxyCommon;
 import tconstruct.tools.logic.*;
 import tconstruct.tools.model.TableRender;
 import tconstruct.util.config.PHConstruct;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ToolBenchBlock extends InventoryBlock {
 

--- a/src/main/java/tconstruct/tools/blocks/ToolForgeBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/ToolForgeBlock.java
@@ -1,7 +1,5 @@
 package tconstruct.tools.blocks;
 
-import mantle.blocks.abstracts.InventoryBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -12,14 +10,15 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryBlock;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.tools.ToolProxyCommon;
 import tconstruct.tools.logic.ToolForgeLogic;
 import tconstruct.tools.model.TableRender;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ToolForgeBlock extends InventoryBlock {
 

--- a/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
@@ -2,8 +2,6 @@ package tconstruct.tools.blocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.InventoryBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -17,14 +15,15 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.InventoryBlock;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.tools.ToolProxyCommon;
 import tconstruct.tools.logic.ToolStationLogic;
 import tconstruct.tools.model.TableRender;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ToolStationBlock extends InventoryBlock {
 

--- a/src/main/java/tconstruct/tools/entity/RotatingBase.java
+++ b/src/main/java/tconstruct/tools/entity/RotatingBase.java
@@ -14,10 +14,10 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
-import tconstruct.library.tools.AbilityHelper;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
 import io.netty.buffer.ByteBuf;
+import tconstruct.library.tools.AbilityHelper;
 
 @Deprecated
 public class RotatingBase extends Entity implements IEntityAdditionalSpawnData {

--- a/src/main/java/tconstruct/tools/gui/CraftingStationGui.java
+++ b/src/main/java/tconstruct/tools/gui/CraftingStationGui.java
@@ -17,16 +17,16 @@ import net.minecraft.world.World;
 
 import org.lwjgl.opengl.GL11;
 
+import codechicken.nei.VisiblityData;
+import codechicken.nei.api.INEIGuiHandler;
+import codechicken.nei.api.TaggedInventoryArea;
+import cpw.mods.fml.common.Optional;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.PatternBuilder;
 import tconstruct.library.modifier.IModifyable;
 import tconstruct.library.tools.ToolMaterial;
 import tconstruct.library.util.HarvestLevels;
 import tconstruct.tools.logic.CraftingStationLogic;
-import codechicken.nei.VisiblityData;
-import codechicken.nei.api.INEIGuiHandler;
-import codechicken.nei.api.TaggedInventoryArea;
-import cpw.mods.fml.common.Optional;
 
 @Optional.Interface(iface = "codechicken.nei.api.INEIGuiHandler", modid = "NotEnoughItems")
 public class CraftingStationGui extends GuiContainer implements INEIGuiHandler {

--- a/src/main/java/tconstruct/tools/gui/FurnaceGui.java
+++ b/src/main/java/tconstruct/tools/gui/FurnaceGui.java
@@ -7,10 +7,10 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.tools.inventory.FurnaceContainer;
-import tconstruct.tools.logic.FurnaceLogic;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.tools.inventory.FurnaceContainer;
+import tconstruct.tools.logic.FurnaceLogic;
 
 @SideOnly(Side.CLIENT)
 public class FurnaceGui extends GuiContainer {

--- a/src/main/java/tconstruct/tools/gui/GuiButtonTool.java
+++ b/src/main/java/tconstruct/tools/gui/GuiButtonTool.java
@@ -6,9 +6,9 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.library.client.ToolGuiElement;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.library.client.ToolGuiElement;
 
 @SideOnly(Side.CLIENT)
 public class GuiButtonTool extends GuiButton {

--- a/src/main/java/tconstruct/tools/gui/MoldingTableGui.java
+++ b/src/main/java/tconstruct/tools/gui/MoldingTableGui.java
@@ -13,6 +13,10 @@ import net.minecraft.world.World;
 
 import org.lwjgl.opengl.GL11;
 
+import codechicken.nei.VisiblityData;
+import codechicken.nei.api.INEIGuiHandler;
+import codechicken.nei.api.TaggedInventoryArea;
+import cpw.mods.fml.common.Optional;
 import tconstruct.TConstruct;
 import tconstruct.library.client.MoldGuiElement;
 import tconstruct.library.client.TConstructClientRegistry;
@@ -20,10 +24,6 @@ import tconstruct.library.crafting.MoldBuilder;
 import tconstruct.tools.inventory.MoldingTableContainer;
 import tconstruct.tools.logic.MoldingTableLogic;
 import tconstruct.util.network.MoldingTablePacket;
-import codechicken.nei.VisiblityData;
-import codechicken.nei.api.INEIGuiHandler;
-import codechicken.nei.api.TaggedInventoryArea;
-import cpw.mods.fml.common.Optional;
 
 @Optional.Interface(iface = "codechicken.nei.api.INEIGuiHandler", modid = "NotEnoughItems")
 public class MoldingTableGui extends GuiContainer implements INEIGuiHandler {

--- a/src/main/java/tconstruct/tools/gui/PartCrafterGui.java
+++ b/src/main/java/tconstruct/tools/gui/PartCrafterGui.java
@@ -12,6 +12,10 @@ import net.minecraft.world.World;
 
 import org.lwjgl.opengl.GL11;
 
+import codechicken.nei.VisiblityData;
+import codechicken.nei.api.INEIGuiHandler;
+import codechicken.nei.api.TaggedInventoryArea;
+import cpw.mods.fml.common.Optional;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.PatternBuilder;
 import tconstruct.library.tools.ToolMaterial;
@@ -19,10 +23,6 @@ import tconstruct.library.util.HarvestLevels;
 import tconstruct.smeltery.inventory.ActiveContainer;
 import tconstruct.tools.inventory.PartCrafterChestContainer;
 import tconstruct.tools.logic.PartBuilderLogic;
-import codechicken.nei.VisiblityData;
-import codechicken.nei.api.INEIGuiHandler;
-import codechicken.nei.api.TaggedInventoryArea;
-import cpw.mods.fml.common.Optional;
 
 @Optional.Interface(iface = "codechicken.nei.api.INEIGuiHandler", modid = "NotEnoughItems")
 public class PartCrafterGui extends GuiContainer implements INEIGuiHandler {

--- a/src/main/java/tconstruct/tools/gui/StencilTableGui.java
+++ b/src/main/java/tconstruct/tools/gui/StencilTableGui.java
@@ -13,6 +13,10 @@ import net.minecraft.world.World;
 
 import org.lwjgl.opengl.GL11;
 
+import codechicken.nei.VisiblityData;
+import codechicken.nei.api.INEIGuiHandler;
+import codechicken.nei.api.TaggedInventoryArea;
+import cpw.mods.fml.common.Optional;
 import tconstruct.TConstruct;
 import tconstruct.library.client.StencilGuiElement;
 import tconstruct.library.client.TConstructClientRegistry;
@@ -21,10 +25,6 @@ import tconstruct.tools.inventory.PatternShaperContainer;
 import tconstruct.tools.logic.StencilTableLogic;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.util.network.PatternTablePacket;
-import codechicken.nei.VisiblityData;
-import codechicken.nei.api.INEIGuiHandler;
-import codechicken.nei.api.TaggedInventoryArea;
-import cpw.mods.fml.common.Optional;
 
 @Optional.Interface(iface = "codechicken.nei.api.INEIGuiHandler", modid = "NotEnoughItems")
 public class StencilTableGui extends GuiContainer implements INEIGuiHandler {

--- a/src/main/java/tconstruct/tools/gui/ToolBenchGui.java
+++ b/src/main/java/tconstruct/tools/gui/ToolBenchGui.java
@@ -5,11 +5,11 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.client.TConstructClientRegistry;
 import tconstruct.library.client.ToolGuiElement;
 import tconstruct.tools.logic.ToolBenchLogic;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class ToolBenchGui extends ToolStationGui {

--- a/src/main/java/tconstruct/tools/gui/ToolForgeGui.java
+++ b/src/main/java/tconstruct/tools/gui/ToolForgeGui.java
@@ -5,11 +5,11 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.client.TConstructClientRegistry;
 import tconstruct.library.client.ToolGuiElement;
 import tconstruct.tools.logic.ToolForgeLogic;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class ToolForgeGui extends ToolStationGui {

--- a/src/main/java/tconstruct/tools/gui/ToolStationGui.java
+++ b/src/main/java/tconstruct/tools/gui/ToolStationGui.java
@@ -15,6 +15,12 @@ import net.minecraft.world.World;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
+import codechicken.nei.VisiblityData;
+import codechicken.nei.api.INEIGuiHandler;
+import codechicken.nei.api.TaggedInventoryArea;
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.TConstruct;
 import tconstruct.library.client.TConstructClientRegistry;
 import tconstruct.library.client.ToolGuiElement;
@@ -22,12 +28,6 @@ import tconstruct.smeltery.inventory.ActiveContainer;
 import tconstruct.tools.inventory.ToolStationContainer;
 import tconstruct.tools.logic.ToolStationLogic;
 import tconstruct.util.network.ToolStationPacket;
-import codechicken.nei.VisiblityData;
-import codechicken.nei.api.INEIGuiHandler;
-import codechicken.nei.api.TaggedInventoryArea;
-import cpw.mods.fml.common.Optional;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 @Optional.Interface(iface = "codechicken.nei.api.INEIGuiHandler", modid = "NotEnoughItems")

--- a/src/main/java/tconstruct/tools/gui/ToolStationGuiHelper.java
+++ b/src/main/java/tconstruct/tools/gui/ToolStationGuiHelper.java
@@ -15,6 +15,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 
+import cpw.mods.fml.client.FMLClientHandler;
 import tconstruct.library.accessory.AccessoryCore;
 import tconstruct.library.armor.ArmorCore;
 import tconstruct.library.modifier.IModifyable;
@@ -25,7 +26,6 @@ import tconstruct.library.util.XpUtils;
 import tconstruct.library.weaponry.AmmoWeapon;
 import tconstruct.library.weaponry.IAmmo;
 import tconstruct.library.weaponry.ProjectileWeapon;
-import cpw.mods.fml.client.FMLClientHandler;
 
 public final class ToolStationGuiHelper {
 

--- a/src/main/java/tconstruct/tools/inventory/FurnaceContainer.java
+++ b/src/main/java/tconstruct/tools/inventory/FurnaceContainer.java
@@ -10,9 +10,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.tileentity.TileEntityFurnace;
 
-import tconstruct.tools.logic.FurnaceLogic;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.tools.logic.FurnaceLogic;
 
 public class FurnaceContainer extends Container {
 

--- a/src/main/java/tconstruct/tools/inventory/InventoryCraftingStation.java
+++ b/src/main/java/tconstruct/tools/inventory/InventoryCraftingStation.java
@@ -1,11 +1,11 @@
 package tconstruct.tools.inventory;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
+
+import mantle.blocks.abstracts.InventoryLogic;
 
 public class InventoryCraftingStation extends InventoryCrafting {
 

--- a/src/main/java/tconstruct/tools/inventory/PatternChestContainer.java
+++ b/src/main/java/tconstruct/tools/inventory/PatternChestContainer.java
@@ -7,10 +7,10 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+import invtweaks.api.container.ChestContainer;
 import tconstruct.library.util.IPattern;
 import tconstruct.tools.TinkerTools;
 import tconstruct.tools.logic.PatternChestLogic;
-import invtweaks.api.container.ChestContainer;
 
 @ChestContainer
 public class PatternChestContainer extends Container {

--- a/src/main/java/tconstruct/tools/itemblocks/CraftingSlabItemBlock.java
+++ b/src/main/java/tconstruct/tools/itemblocks/CraftingSlabItemBlock.java
@@ -1,10 +1,10 @@
 package tconstruct.tools.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class CraftingSlabItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/tools/itemblocks/MultiBrickFancyItem.java
+++ b/src/main/java/tconstruct/tools/itemblocks/MultiBrickFancyItem.java
@@ -2,8 +2,6 @@ package tconstruct.tools.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -11,6 +9,7 @@ import net.minecraft.util.StatCollector;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class MultiBrickFancyItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/tools/itemblocks/MultiBrickItem.java
+++ b/src/main/java/tconstruct/tools/itemblocks/MultiBrickItem.java
@@ -2,8 +2,6 @@ package tconstruct.tools.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -11,6 +9,7 @@ import net.minecraft.util.StatCollector;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class MultiBrickItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/tools/itemblocks/MultiBrickMetalItem.java
+++ b/src/main/java/tconstruct/tools/itemblocks/MultiBrickMetalItem.java
@@ -1,8 +1,8 @@
 package tconstruct.tools.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class MultiBrickMetalItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/tools/itemblocks/ToolBenchItemBlock.java
+++ b/src/main/java/tconstruct/tools/itemblocks/ToolBenchItemBlock.java
@@ -1,8 +1,8 @@
 package tconstruct.tools.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class ToolBenchItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/tools/items/Bowstring.java
+++ b/src/main/java/tconstruct/tools/items/Bowstring.java
@@ -2,16 +2,15 @@ package tconstruct.tools.items;
 
 import java.util.List;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import cpw.mods.fml.common.Loader;
+import mantle.items.abstracts.CraftingItem;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.util.IToolPart;
 import tconstruct.tools.TinkerTools;
-import cpw.mods.fml.common.Loader;
 
 public class Bowstring extends CraftingItem implements IToolPart {
 

--- a/src/main/java/tconstruct/tools/items/CreativeModifier.java
+++ b/src/main/java/tconstruct/tools/items/CreativeModifier.java
@@ -10,12 +10,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.StatCollector;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.crafting.ToolRecipe;
 import tconstruct.library.tools.ToolCore;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class CreativeModifier extends Item {
 

--- a/src/main/java/tconstruct/tools/items/Fletching.java
+++ b/src/main/java/tconstruct/tools/items/Fletching.java
@@ -1,9 +1,8 @@
 package tconstruct.tools.items;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.item.ItemStack;
 
+import mantle.items.abstracts.CraftingItem;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.util.IToolPart;
 

--- a/src/main/java/tconstruct/tools/items/Manual.java
+++ b/src/main/java/tconstruct/tools/items/Manual.java
@@ -2,22 +2,21 @@ package tconstruct.tools.items;
 
 import java.util.List;
 
-import mantle.books.BookData;
-import mantle.client.gui.GuiManual;
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.books.BookData;
+import mantle.client.gui.GuiManual;
+import mantle.items.abstracts.CraftingItem;
 import tconstruct.TConstruct;
 import tconstruct.achievements.TAchievements;
 import tconstruct.client.TProxyClient;
 import tconstruct.library.TConstructRegistry;
-import cpw.mods.fml.client.FMLClientHandler;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class Manual extends CraftingItem {
 

--- a/src/main/java/tconstruct/tools/items/ManualInfo.java
+++ b/src/main/java/tconstruct/tools/items/ManualInfo.java
@@ -1,16 +1,15 @@
 package tconstruct.tools.items;
 
-import mantle.books.BookData;
-import mantle.books.BookDataStore;
-
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
 import org.w3c.dom.Document;
 
-import tconstruct.client.TProxyClient;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
+import mantle.books.BookData;
+import mantle.books.BookDataStore;
+import tconstruct.client.TProxyClient;
 
 public class ManualInfo {
     // static String[] name = new String[] { "beginner", "toolstation", "smeltery", "diary" };

--- a/src/main/java/tconstruct/tools/items/MaterialItem.java
+++ b/src/main/java/tconstruct/tools/items/MaterialItem.java
@@ -2,15 +2,14 @@ package tconstruct.tools.items;
 
 import java.util.List;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.items.abstracts.CraftingItem;
+import tconstruct.library.TConstructRegistry;
 
 public class MaterialItem extends CraftingItem {
 

--- a/src/main/java/tconstruct/tools/items/Pattern.java
+++ b/src/main/java/tconstruct/tools/items/Pattern.java
@@ -4,19 +4,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.items.abstracts.CraftingItem;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.PatternBuilder.MaterialSet;
 import tconstruct.library.util.IPattern;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class Pattern extends CraftingItem implements IPattern {
 

--- a/src/main/java/tconstruct/tools/items/TitleIcon.java
+++ b/src/main/java/tconstruct/tools/items/TitleIcon.java
@@ -17,13 +17,13 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.client.TProxyClient;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.world.entity.BlueSlime;
 import tconstruct.world.entity.KingBlueSlime;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 // spawn egg.
 public class TitleIcon extends Item {

--- a/src/main/java/tconstruct/tools/items/ToolPart.java
+++ b/src/main/java/tconstruct/tools/items/ToolPart.java
@@ -2,13 +2,12 @@ package tconstruct.tools.items;
 
 import java.util.List;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
+import mantle.items.abstracts.CraftingItem;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.util.IToolPart;
 import tconstruct.tools.TinkerTools;

--- a/src/main/java/tconstruct/tools/logic/CraftingStationLogic.java
+++ b/src/main/java/tconstruct/tools/logic/CraftingStationLogic.java
@@ -2,8 +2,6 @@ package tconstruct.tools.logic;
 
 import java.lang.ref.WeakReference;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
@@ -16,6 +14,7 @@ import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import mantle.blocks.abstracts.InventoryLogic;
 import tconstruct.tools.inventory.CraftingStationContainer;
 import tconstruct.util.config.PHConstruct;
 

--- a/src/main/java/tconstruct/tools/logic/EquipLogic.java
+++ b/src/main/java/tconstruct/tools/logic/EquipLogic.java
@@ -1,11 +1,11 @@
 package tconstruct.tools.logic;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
+
+import mantle.blocks.abstracts.InventoryLogic;
 
 /*
  * Slots 0: Frying pan item 1: Fuel 2-9: Food

--- a/src/main/java/tconstruct/tools/logic/FrypanLogic.java
+++ b/src/main/java/tconstruct/tools/logic/FrypanLogic.java
@@ -1,8 +1,5 @@
 package tconstruct.tools.logic;
 
-import mantle.blocks.BlockUtils;
-import mantle.blocks.iface.IActiveLogic;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -14,8 +11,10 @@ import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
-import tconstruct.tools.inventory.FrypanContainer;
 import cpw.mods.fml.common.registry.GameRegistry;
+import mantle.blocks.BlockUtils;
+import mantle.blocks.iface.IActiveLogic;
+import tconstruct.tools.inventory.FrypanContainer;
 
 /*
  * Slots 0: Frying pan item 1: Fuel 2-9: Food

--- a/src/main/java/tconstruct/tools/logic/FurnaceLogic.java
+++ b/src/main/java/tconstruct/tools/logic/FurnaceLogic.java
@@ -1,10 +1,5 @@
 package tconstruct.tools.logic;
 
-import mantle.blocks.BlockUtils;
-import mantle.blocks.abstracts.InventoryLogic;
-import mantle.blocks.iface.IActiveLogic;
-import mantle.blocks.iface.IFacingLogic;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
@@ -23,8 +18,12 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import tconstruct.tools.inventory.FurnaceContainer;
 import cpw.mods.fml.common.registry.GameRegistry;
+import mantle.blocks.BlockUtils;
+import mantle.blocks.abstracts.InventoryLogic;
+import mantle.blocks.iface.IActiveLogic;
+import mantle.blocks.iface.IFacingLogic;
+import tconstruct.tools.inventory.FurnaceContainer;
 
 /*
  * Slots 0: Input 1: Fuel 2: Output 3-16: Chest

--- a/src/main/java/tconstruct/tools/logic/MoldingTableLogic.java
+++ b/src/main/java/tconstruct/tools/logic/MoldingTableLogic.java
@@ -1,7 +1,5 @@
 package tconstruct.tools.logic;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ISidedInventory;
@@ -9,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import mantle.blocks.abstracts.InventoryLogic;
 import tconstruct.library.crafting.MoldBuilder;
 import tconstruct.tools.inventory.MoldingTableContainer;
 

--- a/src/main/java/tconstruct/tools/logic/PartBuilderLogic.java
+++ b/src/main/java/tconstruct/tools/logic/PartBuilderLogic.java
@@ -1,7 +1,5 @@
 package tconstruct.tools.logic;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ISidedInventory;
@@ -10,6 +8,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
+import mantle.blocks.abstracts.InventoryLogic;
 import tconstruct.library.crafting.PatternBuilder;
 import tconstruct.library.util.IPattern;
 import tconstruct.tools.inventory.PartCrafterChestContainer;

--- a/src/main/java/tconstruct/tools/logic/PatternChestLogic.java
+++ b/src/main/java/tconstruct/tools/logic/PatternChestLogic.java
@@ -1,12 +1,11 @@
 package tconstruct.tools.logic;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import mantle.blocks.abstracts.InventoryLogic;
 import tconstruct.library.util.IPattern;
 import tconstruct.tools.inventory.PatternChestContainer;
 

--- a/src/main/java/tconstruct/tools/logic/StencilTableLogic.java
+++ b/src/main/java/tconstruct/tools/logic/StencilTableLogic.java
@@ -1,7 +1,5 @@
 package tconstruct.tools.logic;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ISidedInventory;
@@ -9,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import mantle.blocks.abstracts.InventoryLogic;
 import tconstruct.library.crafting.StencilBuilder;
 import tconstruct.tools.inventory.PatternShaperContainer;
 

--- a/src/main/java/tconstruct/tools/logic/ToolStationLogic.java
+++ b/src/main/java/tconstruct/tools/logic/ToolStationLogic.java
@@ -1,7 +1,5 @@
 package tconstruct.tools.logic;
 
-import mantle.blocks.abstracts.InventoryLogic;
-
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.Container;
@@ -10,6 +8,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
+import mantle.blocks.abstracts.InventoryLogic;
 import tconstruct.library.crafting.ModifyBuilder;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.modifier.IModifyable;

--- a/src/main/java/tconstruct/tools/model/TableRender.java
+++ b/src/main/java/tconstruct/tools/model/TableRender.java
@@ -7,9 +7,9 @@ import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.tools.TinkerTools;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.tools.TinkerTools;
 
 public class TableRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/util/EnvironmentChecks.java
+++ b/src/main/java/tconstruct/util/EnvironmentChecks.java
@@ -1,8 +1,8 @@
 package tconstruct.util;
 
-import mantle.crash.CallableSuppConfig;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.ICrashCallable;
+import mantle.crash.CallableSuppConfig;
 
 public class EnvironmentChecks {
 

--- a/src/main/java/tconstruct/util/IMCHandler.java
+++ b/src/main/java/tconstruct/util/IMCHandler.java
@@ -10,6 +10,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 
+import cofh.api.energy.IEnergyContainerItem;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.event.FMLInterModComms;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.client.TConstructClientRegistry;
@@ -22,10 +26,6 @@ import tconstruct.library.tools.ToolMaterial;
 import tconstruct.library.util.IPattern;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.tools.TinkerTools;
-import cofh.api.energy.IEnergyContainerItem;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.FMLLog;
-import cpw.mods.fml.common.event.FMLInterModComms;
 
 public final class IMCHandler {
 

--- a/src/main/java/tconstruct/util/config/DimensionBlacklist.java
+++ b/src/main/java/tconstruct/util/config/DimensionBlacklist.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 
 import net.minecraftforge.common.config.Configuration;
 
-import tconstruct.TConstruct;
 import cpw.mods.fml.common.Loader;
+import tconstruct.TConstruct;
 
 public class DimensionBlacklist {
 

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -7,10 +7,10 @@ import net.minecraftforge.common.config.ConfigCategory;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 
+import com.google.common.collect.Sets;
+
 import tconstruct.TConstruct;
 import tconstruct.library.tools.AbilityHelper;
-
-import com.google.common.collect.Sets;
 
 public class PHConstruct {
 

--- a/src/main/java/tconstruct/util/network/AccessoryInventoryPacket.java
+++ b/src/main/java/tconstruct/util/network/AccessoryInventoryPacket.java
@@ -1,16 +1,15 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
 import tconstruct.TConstruct;
 import tconstruct.armor.ArmorProxyCommon;
 import tconstruct.armor.TinkerArmor;
 import tconstruct.armor.player.TPlayerStats;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 
 public class AccessoryInventoryPacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/ArmourGuiSyncPacket.java
+++ b/src/main/java/tconstruct/util/network/ArmourGuiSyncPacket.java
@@ -1,15 +1,14 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
-import tconstruct.armor.TinkerArmor;
-import tconstruct.armor.player.TPlayerStats;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
+import tconstruct.armor.TinkerArmor;
+import tconstruct.armor.player.TPlayerStats;
 
 /**
  * This Packet is for sending the players TPlayerStats from the server to the client.

--- a/src/main/java/tconstruct/util/network/BeltPacket.java
+++ b/src/main/java/tconstruct/util/network/BeltPacket.java
@@ -1,13 +1,12 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 
-import tconstruct.armor.PlayerAbilityHelper;
-import tconstruct.armor.player.TPlayerStats;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
+import tconstruct.armor.PlayerAbilityHelper;
+import tconstruct.armor.player.TPlayerStats;
 
 public class BeltPacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/DoubleJumpPacket.java
+++ b/src/main/java/tconstruct/util/network/DoubleJumpPacket.java
@@ -1,11 +1,10 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
 
 public class DoubleJumpPacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/GogglePacket.java
+++ b/src/main/java/tconstruct/util/network/GogglePacket.java
@@ -1,12 +1,11 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 
-import tconstruct.armor.PlayerAbilityHelper;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
+import tconstruct.armor.PlayerAbilityHelper;
 
 public class GogglePacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/HealthUpdatePacket.java
+++ b/src/main/java/tconstruct/util/network/HealthUpdatePacket.java
@@ -1,13 +1,12 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 
-import tconstruct.armor.ArmorProxyClient;
-import tconstruct.armor.player.TPlayerStats;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
+import tconstruct.armor.ArmorProxyClient;
+import tconstruct.armor.player.TPlayerStats;
 
 public class HealthUpdatePacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/MoldingTablePacket.java
+++ b/src/main/java/tconstruct/util/network/MoldingTablePacket.java
@@ -1,17 +1,16 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
+import cpw.mods.fml.common.network.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
 import tconstruct.TConstruct;
 import tconstruct.library.crafting.MoldBuilder;
 import tconstruct.tools.inventory.MoldingTableContainer;
 import tconstruct.tools.logic.MoldingTableLogic;
-import cpw.mods.fml.common.network.ByteBufUtils;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 
 public class MoldingTablePacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/MovementUpdatePacket.java
+++ b/src/main/java/tconstruct/util/network/MovementUpdatePacket.java
@@ -1,12 +1,11 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
 
 public class MovementUpdatePacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/PacketPipeline.java
+++ b/src/main/java/tconstruct/util/network/PacketPipeline.java
@@ -2,9 +2,6 @@ package tconstruct.util.network;
 
 import java.util.*;
 
-import mantle.common.network.AbstractPacket;
-import mantle.common.network.PacketUpdateTE;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -23,6 +20,8 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageCodec;
+import mantle.common.network.AbstractPacket;
+import mantle.common.network.PacketUpdateTE;
 
 /**
  * Packet pipeline class. Directs all registered packet data to be handled by the packets themselves.

--- a/src/main/java/tconstruct/util/network/PatternTablePacket.java
+++ b/src/main/java/tconstruct/util/network/PatternTablePacket.java
@@ -1,17 +1,16 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
+import cpw.mods.fml.common.network.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
 import tconstruct.TConstruct;
 import tconstruct.library.crafting.StencilBuilder;
 import tconstruct.tools.inventory.PatternShaperContainer;
 import tconstruct.tools.logic.StencilTableLogic;
-import cpw.mods.fml.common.network.ByteBufUtils;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 
 public class PatternTablePacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/SignDataPacket.java
+++ b/src/main/java/tconstruct/util/network/SignDataPacket.java
@@ -1,15 +1,14 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 
-import tconstruct.TConstruct;
-import tconstruct.tools.logic.BattlesignLogic;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
+import tconstruct.TConstruct;
+import tconstruct.tools.logic.BattlesignLogic;
 
 public class SignDataPacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/SmelteryPacket.java
+++ b/src/main/java/tconstruct/util/network/SmelteryPacket.java
@@ -1,17 +1,16 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-import mantle.common.network.PacketUpdateTE;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
+import mantle.common.network.PacketUpdateTE;
 import tconstruct.TConstruct;
 import tconstruct.smeltery.inventory.SmelteryContainer;
 import tconstruct.smeltery.logic.SmelteryLogic;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 
 public class SmelteryPacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/util/network/ToolStationPacket.java
+++ b/src/main/java/tconstruct/util/network/ToolStationPacket.java
@@ -1,14 +1,13 @@
 package tconstruct.util.network;
 
-import mantle.common.network.AbstractPacket;
-
 import net.minecraft.entity.player.EntityPlayer;
 
-import tconstruct.tools.inventory.ToolStationContainer;
-import tconstruct.tools.logic.ToolStationLogic;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
+import tconstruct.tools.inventory.ToolStationContainer;
+import tconstruct.tools.logic.ToolStationLogic;
 
 public class ToolStationPacket extends AbstractPacket {
 

--- a/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
+++ b/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
@@ -5,9 +5,6 @@ import static tconstruct.tools.TinkerTools.MaterialID;
 import java.util.Map;
 import java.util.Random;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-
 import net.minecraft.block.BlockDispenser;
 import net.minecraft.dispenser.IPosition;
 import net.minecraft.init.Blocks;
@@ -21,6 +18,14 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.SidedProxy;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.*;
@@ -50,12 +55,6 @@ import tconstruct.weaponry.entity.*;
 import tconstruct.weaponry.items.*;
 import tconstruct.weaponry.weapons.*;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.SidedProxy;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
 
 @GameRegistry.ObjectHolder(TConstruct.modID)
 @Pulse(
@@ -232,7 +231,6 @@ public class TinkerWeaponry {
         StencilBuilder.registerStencil(25, woodPattern, 1); // crossbow limb
         if (!PHConstruct.balancedPartCrafting) StencilBuilder.registerStencil(26, woodPattern, 2); // crossbow body
         StencilBuilder.registerStencil(27, woodPattern, 3); // bow limb
-
 
         PatternBuilder.instance.addToolPattern(woodPattern);
 

--- a/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
+++ b/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
@@ -224,16 +224,15 @@ public class TinkerWeaponry {
     }
 
     private void addPartRecipes() {
-        StencilBuilder.registerStencil(11, TinkerTools.woodPattern, 25); // arrow head
-        StencilBuilder.registerStencil(12, TinkerTools.woodPattern, 24); // fletchling
+        StencilBuilder.registerStencil(21, TinkerTools.woodPattern, 25); // arrow head
+        StencilBuilder.registerStencil(22, TinkerTools.woodPattern, 24); // fletchling
+        StencilBuilder.registerStencil(23, TinkerTools.woodPattern, 23); // bowstring
 
-        StencilBuilder.registerStencil(13, woodPattern, 3); // bow limb
-        StencilBuilder.registerStencil(14, TinkerTools.woodPattern, 23); // bowstring
-        StencilBuilder.registerStencil(15, woodPattern, 1); // crossbow limb
+        StencilBuilder.registerStencil(24, woodPattern, 0); // shuriken
+        StencilBuilder.registerStencil(25, woodPattern, 1); // crossbow limb
+        if (!PHConstruct.balancedPartCrafting) StencilBuilder.registerStencil(26, woodPattern, 2); // crossbow body
+        StencilBuilder.registerStencil(27, woodPattern, 3); // bow limb
 
-        StencilBuilder.registerStencil(16, woodPattern, 0); // shuriken
-
-        if (!PHConstruct.balancedPartCrafting) StencilBuilder.registerStencil(17, woodPattern, 2); // crossbow body
 
         PatternBuilder.instance.addToolPattern(woodPattern);
 

--- a/src/main/java/tconstruct/weaponry/WeaponryClientProxy.java
+++ b/src/main/java/tconstruct/weaponry/WeaponryClientProxy.java
@@ -2,13 +2,13 @@ package tconstruct.weaponry;
 
 import static tconstruct.weaponry.TinkerWeaponry.*;
 
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
 
+import cpw.mods.fml.client.registry.RenderingRegistry;
+import mantle.lib.client.MantleClientRegistry;
 import tconstruct.client.AmmoItemRenderer;
 import tconstruct.library.client.TConstructClientRegistry;
 import tconstruct.library.crafting.ToolBuilder;
@@ -29,7 +29,6 @@ import tconstruct.weaponry.client.item.CrossbowRenderer;
 import tconstruct.weaponry.client.item.JavelinRenderer;
 import tconstruct.weaponry.client.item.ThrowingKnifeRenderer;
 import tconstruct.weaponry.entity.*;
-import cpw.mods.fml.client.registry.RenderingRegistry;
 
 public class WeaponryClientProxy extends WeaponryCommonProxy {
 

--- a/src/main/java/tconstruct/weaponry/WeaponryClientProxy.java
+++ b/src/main/java/tconstruct/weaponry/WeaponryClientProxy.java
@@ -115,29 +115,30 @@ public class WeaponryClientProxy extends WeaponryCommonProxy {
 
         // Stencil Table
         if (PHConstruct.balancedPartCrafting) {
-            TConstructClientRegistry.addStencilButton2(11, 3, 11, Reference.RESOURCE, tex); // arrow head
-            TConstructClientRegistry.addStencilButton2(12, 3, 12, Reference.RESOURCE, tex); // fletchling
+            TConstructClientRegistry.addStencilButton2(11, 3, 21, Reference.RESOURCE, tex); // arrow head
+            TConstructClientRegistry.addStencilButton2(12, 3, 22, Reference.RESOURCE, tex); // fletchling
             TConstructClientRegistry.addStencilButton2(0, 0, -1, null, null);
 
-            TConstructClientRegistry.addStencilButton2(3, 4, 13, Reference.RESOURCE, tex); // bow limb
-            TConstructClientRegistry.addStencilButton2(10, 3, 14, Reference.RESOURCE, tex); // bowstring
-            TConstructClientRegistry.addStencilButton2(1, 4, 15, Reference.RESOURCE, tex); // crossbow limb
+            TConstructClientRegistry.addStencilButton2(3, 4, 27, Reference.RESOURCE, tex); // bow limb
+            TConstructClientRegistry.addStencilButton2(10, 3, 23, Reference.RESOURCE, tex); // bowstring
+            TConstructClientRegistry.addStencilButton2(1, 4, 25, Reference.RESOURCE, tex); // crossbow limb
 
-            TConstructClientRegistry.addStencilButton2(0, 4, 16, Reference.RESOURCE, tex); // shuriken
+            TConstructClientRegistry.addStencilButton2(0, 4, 24, Reference.RESOURCE, tex); // shuriken
             // TConstructClientRegistry.addStencilButton2(4, 4, index, Reference.RESOURCE, "textures/gui/icons.png"); //
             // bolt
 
         } else {
-            TConstructClientRegistry.addStencilButton2(11, 3, 11, Reference.RESOURCE, tex); // arrow head
-            TConstructClientRegistry.addStencilButton2(12, 3, 12, Reference.RESOURCE, tex); // fletchling
+            TConstructClientRegistry.addStencilButton2(11, 3, 21, Reference.RESOURCE, tex); // arrow head
+            TConstructClientRegistry.addStencilButton2(12, 3, 22, Reference.RESOURCE, tex); // fletchling
+            TConstructClientRegistry.addStencilButton2(0, 0, -1, null, null);
             TConstructClientRegistry.addStencilButton2(0, 0, -1, null, null);
 
-            TConstructClientRegistry.addStencilButton2(3, 4, 13, Reference.RESOURCE, tex); // bow limb
-            TConstructClientRegistry.addStencilButton2(10, 3, 14, Reference.RESOURCE, tex); // bowstring
-            TConstructClientRegistry.addStencilButton2(1, 4, 15, Reference.RESOURCE, tex); // crossbow limb
-            TConstructClientRegistry.addStencilButton2(2, 4, 17, Reference.RESOURCE, tex); // crossbow body
-            TConstructClientRegistry.addStencilButton2(0, 0, -1, null, null);
-            TConstructClientRegistry.addStencilButton2(0, 4, 16, Reference.RESOURCE, tex); // shuriken
+            TConstructClientRegistry.addStencilButton2(3, 4, 27, Reference.RESOURCE, tex); // bow limb
+            TConstructClientRegistry.addStencilButton2(10, 3, 23, Reference.RESOURCE, tex); // bowstring
+            TConstructClientRegistry.addStencilButton2(1, 4, 25, Reference.RESOURCE, tex); // crossbow limb
+            TConstructClientRegistry.addStencilButton2(2, 4, 26, Reference.RESOURCE, tex); // crossbow body
+
+            TConstructClientRegistry.addStencilButton2(0, 4, 24, Reference.RESOURCE, tex); // shuriken
             // TConstructClientRegistry.addStencilButton2(4, 4, index, Reference.RESOURCE, "textures/gui/icons.png"); //
             // bolt
 

--- a/src/main/java/tconstruct/weaponry/WeaponryCommonProxy.java
+++ b/src/main/java/tconstruct/weaponry/WeaponryCommonProxy.java
@@ -1,8 +1,8 @@
 package tconstruct.weaponry;
 
+import cpw.mods.fml.common.registry.EntityRegistry;
 import tconstruct.TConstruct;
 import tconstruct.weaponry.entity.*;
-import cpw.mods.fml.common.registry.EntityRegistry;
 
 public class WeaponryCommonProxy {
 

--- a/src/main/java/tconstruct/weaponry/WeaponryHandler.java
+++ b/src/main/java/tconstruct/weaponry/WeaponryHandler.java
@@ -10,6 +10,10 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 
+import cpw.mods.fml.common.eventhandler.Event;
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
 import tconstruct.armor.player.TPlayerStats;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.PatternBuilder;
@@ -32,10 +36,6 @@ import tconstruct.weaponry.ammo.BoltAmmo;
 import tconstruct.weaponry.weapons.Crossbow;
 import tconstruct.weaponry.weapons.LongBow;
 import tconstruct.weaponry.weapons.ShortBow;
-import cpw.mods.fml.common.eventhandler.Event;
-import cpw.mods.fml.common.eventhandler.EventPriority;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.gameevent.PlayerEvent;
 
 public class WeaponryHandler {
 

--- a/src/main/java/tconstruct/weaponry/client/AmmoSlotHandler.java
+++ b/src/main/java/tconstruct/weaponry/client/AmmoSlotHandler.java
@@ -6,8 +6,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 
-import tconstruct.library.weaponry.ProjectileWeapon;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import tconstruct.library.weaponry.ProjectileWeapon;
 
 public class AmmoSlotHandler {
 

--- a/src/main/java/tconstruct/weaponry/client/CrosshairHandler.java
+++ b/src/main/java/tconstruct/weaponry/client/CrosshairHandler.java
@@ -10,9 +10,9 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import tconstruct.library.weaponry.IWindup;
 import tconstruct.util.Reference;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class CrosshairHandler {
 

--- a/src/main/java/tconstruct/weaponry/client/RenderEventHandler.java
+++ b/src/main/java/tconstruct/weaponry/client/RenderEventHandler.java
@@ -4,10 +4,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import tconstruct.library.weaponry.BowBaseAmmo;
 import tconstruct.library.weaponry.IWindup;
 import tconstruct.weaponry.TinkerWeaponry;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class RenderEventHandler {
 

--- a/src/main/java/tconstruct/weaponry/entity/JavelinEntity.java
+++ b/src/main/java/tconstruct/weaponry/entity/JavelinEntity.java
@@ -4,9 +4,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import io.netty.buffer.ByteBuf;
 import tconstruct.library.entity.ProjectileBase;
 import tconstruct.weaponry.TinkerWeaponry;
-import io.netty.buffer.ByteBuf;
 
 public class JavelinEntity extends ProjectileBase {
 

--- a/src/main/java/tconstruct/weaponry/entity/ShurikenEntity.java
+++ b/src/main/java/tconstruct/weaponry/entity/ShurikenEntity.java
@@ -4,9 +4,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import io.netty.buffer.ByteBuf;
 import tconstruct.library.entity.ProjectileBase;
 import tconstruct.weaponry.TinkerWeaponry;
-import io.netty.buffer.ByteBuf;
 
 public class ShurikenEntity extends ProjectileBase {
 

--- a/src/main/java/tconstruct/weaponry/items/Boneana.java
+++ b/src/main/java/tconstruct/weaponry/items/Boneana.java
@@ -8,10 +8,10 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 
-import tconstruct.items.tools.Broadsword;
-import tconstruct.util.Reference;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.items.tools.Broadsword;
+import tconstruct.util.Reference;
 
 public class Boneana extends Broadsword {
 

--- a/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
+++ b/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
@@ -2,8 +2,6 @@ package tconstruct.weaponry.weapons;
 
 import java.util.List;
 
-import mods.battlegear2.api.core.InventoryPlayerBattle;
-
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityArrow;
@@ -13,6 +11,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.Loader;
+import mods.battlegear2.api.core.InventoryPlayerBattle;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.tools.AbilityHelper;
@@ -25,7 +25,6 @@ import tconstruct.util.Reference;
 import tconstruct.weaponry.TinkerWeaponry;
 import tconstruct.weaponry.ammo.BoltAmmo;
 import tconstruct.weaponry.entity.BoltEntity;
-import cpw.mods.fml.common.Loader;
 
 public class Crossbow extends ProjectileWeapon {
 

--- a/src/main/java/tconstruct/weaponry/weapons/Javelin.java
+++ b/src/main/java/tconstruct/weaponry/weapons/Javelin.java
@@ -7,14 +7,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.library.weaponry.AmmoWeapon;
 import tconstruct.tools.TinkerTools;
 import tconstruct.weaponry.TinkerWeaponry;
 import tconstruct.weaponry.client.CrosshairType;
 import tconstruct.weaponry.entity.JavelinEntity;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class Javelin extends AmmoWeapon {
 

--- a/src/main/java/tconstruct/weaponry/weapons/ShortBow.java
+++ b/src/main/java/tconstruct/weaponry/weapons/ShortBow.java
@@ -8,11 +8,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.weaponry.BowBaseAmmo;
 import tconstruct.weaponry.TinkerWeaponry;
 import tconstruct.weaponry.ammo.ArrowAmmo;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ShortBow extends BowBaseAmmo {
 

--- a/src/main/java/tconstruct/weaponry/weapons/Shuriken.java
+++ b/src/main/java/tconstruct/weaponry/weapons/Shuriken.java
@@ -12,13 +12,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.client.IconFlipped;
 import tconstruct.library.weaponry.AmmoWeapon;
 import tconstruct.weaponry.TinkerWeaponry;
 import tconstruct.weaponry.client.CrosshairType;
 import tconstruct.weaponry.entity.ShurikenEntity;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class Shuriken extends AmmoWeapon {
 

--- a/src/main/java/tconstruct/weaponry/weapons/ThrowingKnife.java
+++ b/src/main/java/tconstruct/weaponry/weapons/ThrowingKnife.java
@@ -7,13 +7,13 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.entity.ProjectileBase;
 import tconstruct.library.weaponry.AmmoWeapon;
 import tconstruct.tools.TinkerTools;
 import tconstruct.weaponry.client.CrosshairType;
 import tconstruct.weaponry.entity.ThrowingKnifeEntity;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ThrowingKnife extends AmmoWeapon {
 

--- a/src/main/java/tconstruct/world/TinkerWorld.java
+++ b/src/main/java/tconstruct/world/TinkerWorld.java
@@ -1,9 +1,5 @@
 package tconstruct.world;
 
-import mantle.pulsar.pulse.Handler;
-import mantle.pulsar.pulse.Pulse;
-import mantle.utils.RecipeRemover;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.Block.SoundType;
 import net.minecraft.block.material.Material;
@@ -25,6 +21,17 @@ import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
+import cpw.mods.fml.common.Mod.Instance;
+import cpw.mods.fml.common.SidedProxy;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.registry.EntityRegistry;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
+import mantle.utils.RecipeRemover;
 import tconstruct.TConstruct;
 import tconstruct.armor.TinkerArmor;
 import tconstruct.blocks.SlabBase;
@@ -59,14 +66,6 @@ import tconstruct.world.itemblocks.*;
 import tconstruct.world.items.GoldenHead;
 import tconstruct.world.items.OreBerries;
 import tconstruct.world.items.StrangeFood;
-import cpw.mods.fml.common.Mod.Instance;
-import cpw.mods.fml.common.SidedProxy;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.registry.EntityRegistry;
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 
 @ObjectHolder(TConstruct.modID)
 @Pulse(id = "Tinkers' World", description = "Ores, slime islands, essence berries, and the like.", forced = true)

--- a/src/main/java/tconstruct/world/TinkerWorldEvents.java
+++ b/src/main/java/tconstruct/world/TinkerWorldEvents.java
@@ -21,12 +21,12 @@ import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.player.BonemealEvent;
 
+import cpw.mods.fml.common.eventhandler.Event;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import tconstruct.TConstruct;
 import tconstruct.tools.TinkerTools;
 import tconstruct.util.ItemHelper;
 import tconstruct.util.config.PHConstruct;
-import cpw.mods.fml.common.eventhandler.Event;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class TinkerWorldEvents {
 

--- a/src/main/java/tconstruct/world/TinkerWorldProxyClient.java
+++ b/src/main/java/tconstruct/world/TinkerWorldProxyClient.java
@@ -1,7 +1,5 @@
 package tconstruct.world;
 
-import mantle.lib.client.MantleClientRegistry;
-
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelSlime;
@@ -11,14 +9,15 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
+import cpw.mods.fml.client.registry.RenderingRegistry;
+import cpw.mods.fml.common.registry.VillagerRegistry;
+import mantle.lib.client.MantleClientRegistry;
 import tconstruct.mechworks.model.CartRender;
 import tconstruct.tools.TinkerTools;
 import tconstruct.world.entity.BlueSlime;
 import tconstruct.world.entity.CartEntity;
 import tconstruct.world.entity.KingBlueSlime;
 import tconstruct.world.model.*;
-import cpw.mods.fml.client.registry.RenderingRegistry;
-import cpw.mods.fml.common.registry.VillagerRegistry;
 
 public class TinkerWorldProxyClient extends TinkerWorldProxyCommon {
 

--- a/src/main/java/tconstruct/world/blocks/ConveyorBase.java
+++ b/src/main/java/tconstruct/world/blocks/ConveyorBase.java
@@ -1,7 +1,5 @@
 package tconstruct.world.blocks;
 
-import mantle.blocks.MantleBlock;
-
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -14,10 +12,11 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.library.TConstructRegistry;
-import tconstruct.world.model.SlimeChannelRender;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
+import tconstruct.library.TConstructRegistry;
+import tconstruct.world.model.SlimeChannelRender;
 
 public class ConveyorBase extends MantleBlock {
 

--- a/src/main/java/tconstruct/world/blocks/GravelOre.java
+++ b/src/main/java/tconstruct/world/blocks/GravelOre.java
@@ -12,10 +12,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
-import tconstruct.library.TConstructRegistry;
-import tconstruct.world.TinkerWorld;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.library.TConstructRegistry;
+import tconstruct.world.TinkerWorld;
 
 public class GravelOre extends BlockSand {
 

--- a/src/main/java/tconstruct/world/blocks/MeatBlock.java
+++ b/src/main/java/tconstruct/world/blocks/MeatBlock.java
@@ -13,9 +13,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.library.TConstructRegistry;
 
 public class MeatBlock extends BlockWood {
 

--- a/src/main/java/tconstruct/world/blocks/OreberryBush.java
+++ b/src/main/java/tconstruct/world/blocks/OreberryBush.java
@@ -23,12 +23,12 @@ import net.minecraftforge.common.EnumPlantType;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.world.TinkerWorld;
 import tconstruct.world.model.OreberryRender;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class OreberryBush extends BlockLeavesBase implements IPlantable {
 

--- a/src/main/java/tconstruct/world/blocks/SlimeExplosive.java
+++ b/src/main/java/tconstruct/world/blocks/SlimeExplosive.java
@@ -2,8 +2,6 @@ package tconstruct.world.blocks;
 
 import java.util.List;
 
-import mantle.world.WorldHelper;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
@@ -18,10 +16,11 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 
-import tconstruct.blocks.TConstructBlock;
-import tconstruct.mechworks.entity.item.ExplosivePrimed;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.world.WorldHelper;
+import tconstruct.blocks.TConstructBlock;
+import tconstruct.mechworks.entity.item.ExplosivePrimed;
 
 public class SlimeExplosive extends TConstructBlock {
 

--- a/src/main/java/tconstruct/world/blocks/SlimePad.java
+++ b/src/main/java/tconstruct/world/blocks/SlimePad.java
@@ -1,7 +1,5 @@
 package tconstruct.world.blocks;
 
-import mantle.blocks.MantleBlock;
-
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -13,11 +11,12 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.world.TinkerWorld;
 import tconstruct.world.model.SlimePadRender;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class SlimePad extends MantleBlock {
 

--- a/src/main/java/tconstruct/world/blocks/SoilSlab.java
+++ b/src/main/java/tconstruct/world/blocks/SoilSlab.java
@@ -12,11 +12,11 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.ColorizerGrass;
 import net.minecraft.world.IBlockAccess;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.blocks.SlabBase;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.tools.TinkerTools;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class SoilSlab extends SlabBase {
 

--- a/src/main/java/tconstruct/world/blocks/StoneTorch.java
+++ b/src/main/java/tconstruct/world/blocks/StoneTorch.java
@@ -4,8 +4,6 @@ import static net.minecraftforge.common.util.ForgeDirection.*;
 
 import java.util.Random;
 
-import mantle.blocks.MantleBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -17,6 +15,7 @@ import net.minecraft.world.World;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.MantleBlock;
 
 public class StoneTorch extends MantleBlock {
 

--- a/src/main/java/tconstruct/world/gen/SlimeIslandGen.java
+++ b/src/main/java/tconstruct/world/gen/SlimeIslandGen.java
@@ -13,11 +13,11 @@ import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.ChunkProviderFlat;
 import net.minecraft.world.gen.feature.WorldGenerator;
 
+import cpw.mods.fml.common.IWorldGenerator;
 import tconstruct.tools.TinkerTools;
 import tconstruct.util.config.DimensionBlacklist;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.common.IWorldGenerator;
 
 public class SlimeIslandGen extends WorldGenerator implements IWorldGenerator {
 

--- a/src/main/java/tconstruct/world/gen/TBaseWorldGenerator.java
+++ b/src/main/java/tconstruct/world/gen/TBaseWorldGenerator.java
@@ -10,9 +10,9 @@ import net.minecraft.world.WorldType;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.feature.WorldGenMinable;
 
+import cpw.mods.fml.common.IWorldGenerator;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.common.IWorldGenerator;
 
 public class TBaseWorldGenerator implements IWorldGenerator {
 

--- a/src/main/java/tconstruct/world/gen/TerrainGenEventHandler.java
+++ b/src/main/java/tconstruct/world/gen/TerrainGenEventHandler.java
@@ -10,12 +10,12 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate;
 
-import tconstruct.util.config.PHConstruct;
-import tconstruct.world.TinkerWorld;
-
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import tconstruct.util.config.PHConstruct;
+import tconstruct.world.TinkerWorld;
 
 public class TerrainGenEventHandler {
 

--- a/src/main/java/tconstruct/world/itemblocks/CraftedSoilItemBlock.java
+++ b/src/main/java/tconstruct/world/itemblocks/CraftedSoilItemBlock.java
@@ -2,8 +2,6 @@ package tconstruct.world.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -12,6 +10,7 @@ import net.minecraft.util.StatCollector;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class CraftedSoilItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/GravelOreItem.java
+++ b/src/main/java/tconstruct/world/itemblocks/GravelOreItem.java
@@ -1,8 +1,8 @@
 package tconstruct.world.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class GravelOreItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/MetalOreItemBlock.java
+++ b/src/main/java/tconstruct/world/itemblocks/MetalOreItemBlock.java
@@ -2,12 +2,12 @@ package tconstruct.world.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class MetalOreItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/OreberryBushItem.java
+++ b/src/main/java/tconstruct/world/itemblocks/OreberryBushItem.java
@@ -2,9 +2,6 @@ package tconstruct.world.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-import mantle.world.WorldHelper;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -13,9 +10,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import tconstruct.world.TinkerWorld;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.MultiItemBlock;
+import mantle.world.WorldHelper;
+import tconstruct.world.TinkerWorld;
 
 public class OreberryBushItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/OreberryBushSecondItem.java
+++ b/src/main/java/tconstruct/world/itemblocks/OreberryBushSecondItem.java
@@ -2,9 +2,6 @@ package tconstruct.world.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-import mantle.world.WorldHelper;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -13,9 +10,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import tconstruct.world.TinkerWorld;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.MultiItemBlock;
+import mantle.world.WorldHelper;
+import tconstruct.world.TinkerWorld;
 
 public class OreberryBushSecondItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/SlimeGelItemBlock.java
+++ b/src/main/java/tconstruct/world/itemblocks/SlimeGelItemBlock.java
@@ -1,8 +1,8 @@
 package tconstruct.world.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class SlimeGelItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/SlimeGrassItemBlock.java
+++ b/src/main/java/tconstruct/world/itemblocks/SlimeGrassItemBlock.java
@@ -1,8 +1,8 @@
 package tconstruct.world.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class SlimeGrassItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/SlimeLeavesItemBlock.java
+++ b/src/main/java/tconstruct/world/itemblocks/SlimeLeavesItemBlock.java
@@ -1,8 +1,8 @@
 package tconstruct.world.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class SlimeLeavesItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/SlimeSaplingItemBlock.java
+++ b/src/main/java/tconstruct/world/itemblocks/SlimeSaplingItemBlock.java
@@ -1,8 +1,8 @@
 package tconstruct.world.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class SlimeSaplingItemBlock extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/SlimeTallGrassItem.java
+++ b/src/main/java/tconstruct/world/itemblocks/SlimeTallGrassItem.java
@@ -1,14 +1,13 @@
 package tconstruct.world.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 
-import tconstruct.world.TinkerWorld;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.MultiItemBlock;
+import tconstruct.world.TinkerWorld;
 
 public class SlimeTallGrassItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/SoilSlabItem.java
+++ b/src/main/java/tconstruct/world/itemblocks/SoilSlabItem.java
@@ -2,8 +2,6 @@ package tconstruct.world.itemblocks;
 
 import java.util.List;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -11,6 +9,7 @@ import net.minecraft.util.StatCollector;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class SoilSlabItem extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/WoolSlab1Item.java
+++ b/src/main/java/tconstruct/world/itemblocks/WoolSlab1Item.java
@@ -1,7 +1,5 @@
 package tconstruct.world.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -9,6 +7,8 @@ import net.minecraft.item.ItemDye;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class WoolSlab1Item extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/itemblocks/WoolSlab2Item.java
+++ b/src/main/java/tconstruct/world/itemblocks/WoolSlab2Item.java
@@ -1,7 +1,5 @@
 package tconstruct.world.itemblocks;
 
-import mantle.blocks.abstracts.MultiItemBlock;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -9,6 +7,8 @@ import net.minecraft.item.ItemDye;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
+
+import mantle.blocks.abstracts.MultiItemBlock;
 
 public class WoolSlab2Item extends MultiItemBlock {
 

--- a/src/main/java/tconstruct/world/items/OreBerries.java
+++ b/src/main/java/tconstruct/world/items/OreBerries.java
@@ -2,8 +2,6 @@ package tconstruct.world.items;
 
 import java.util.List;
 
-import mantle.items.abstracts.CraftingItem;
-
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.entity.player.EntityPlayer;
@@ -11,9 +9,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import tconstruct.library.TConstructRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.items.abstracts.CraftingItem;
+import tconstruct.library.TConstructRegistry;
 
 public class OreBerries extends CraftingItem {
 

--- a/src/main/java/tconstruct/world/model/BarricadeRender.java
+++ b/src/main/java/tconstruct/world/model/BarricadeRender.java
@@ -4,9 +4,9 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
-import tconstruct.util.ItemHelper;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.util.ItemHelper;
 
 public class BarricadeRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/world/model/CrystalRender.java
+++ b/src/main/java/tconstruct/world/model/CrystalRender.java
@@ -6,9 +6,9 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.ResourceLocation;
 
-import tconstruct.world.entity.Crystal;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.world.entity.Crystal;
 
 @SideOnly(Side.CLIENT)
 public class CrystalRender extends RenderLiving {

--- a/src/main/java/tconstruct/world/model/OreberryRender.java
+++ b/src/main/java/tconstruct/world/model/OreberryRender.java
@@ -4,9 +4,9 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
-import tconstruct.util.ItemHelper;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.util.ItemHelper;
 
 public class OreberryRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/world/model/RenderLandmine.java
+++ b/src/main/java/tconstruct/world/model/RenderLandmine.java
@@ -7,9 +7,9 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.mechworks.landmine.Helper;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.mechworks.landmine.Helper;
 
 /**
  *

--- a/src/main/java/tconstruct/world/model/SlimeChannelRender.java
+++ b/src/main/java/tconstruct/world/model/SlimeChannelRender.java
@@ -7,9 +7,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 
-import tconstruct.util.ItemHelper;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import tconstruct.util.ItemHelper;
 
 public class SlimeChannelRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/world/model/SlimePadRender.java
+++ b/src/main/java/tconstruct/world/model/SlimePadRender.java
@@ -4,12 +4,12 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
+import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import cpw.mods.fml.client.registry.RenderingRegistry;
 import tconstruct.client.BlockSkinRenderHelper;
 import tconstruct.util.ItemHelper;
 import tconstruct.world.TinkerWorld;
 import tconstruct.world.blocks.SlimePad;
-import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
-import cpw.mods.fml.client.registry.RenderingRegistry;
 
 public class SlimePadRender implements ISimpleBlockRenderingHandler {
 

--- a/src/main/java/tconstruct/world/model/SlimeRender.java
+++ b/src/main/java/tconstruct/world/model/SlimeRender.java
@@ -10,10 +10,10 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import tconstruct.world.entity.KingBlueSlime;
-import tconstruct.world.entity.SlimeBase;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.world.entity.KingBlueSlime;
+import tconstruct.world.entity.SlimeBase;
 
 @SideOnly(Side.CLIENT)
 public class SlimeRender extends RenderLiving {

--- a/src/main/java/tconstruct/world/village/TVillageTrades.java
+++ b/src/main/java/tconstruct/world/village/TVillageTrades.java
@@ -10,11 +10,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.village.MerchantRecipe;
 import net.minecraft.village.MerchantRecipeList;
 
+import cpw.mods.fml.common.registry.VillagerRegistry.IVillageTradeHandler;
 import tconstruct.mechworks.TinkerMechworks;
 import tconstruct.tools.TinkerTools;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.world.TinkerWorld;
-import cpw.mods.fml.common.registry.VillagerRegistry.IVillageTradeHandler;
 
 public class TVillageTrades implements IVillageTradeHandler {
 


### PR DESCRIPTION
Closes https://github.com/DrParadox7/Lost-Era-Modpack/issues/65

Tested this in the full pack, works fine.

Fixes all problems noted in the linked issue, plus one I found when disabling `balancedPartCrafting`:

With the addition of that config option, you shifted stencil ids around to make them sequential when it is enabled, which is not necessary as nothing assumes they are sequential. The case for that config being disabled was not handled, leading to duplicate stencil ids, which causes some very fun crashes due to weaponry init getting cancelled before it finishes.

All stencil ids have been restored to their previous values and the stencil table gui has been updated accordingly (and restored to its previous layout if `balancedPartCrafting == false`, there was a weird gap previously).

Also features an enormous `spotlessApply`, seems the import ordering rules changed.